### PR TITLE
Exclude examples from Dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Intentionally vulnerable examples — do not update
+  - package-ecosystem: "npm"
+    directory: "/examples"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

Examples contain intentionally vulnerable dependencies for testing (e.g., `mcp-remote@0.1.10`). Dependabot flags them as vulnerabilities — correct but not actionable.

Sets `open-pull-requests-limit: 0` for `/examples` npm ecosystem to suppress alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)