### PR TITLE
feat(aibom): Day 8 — Hugging Face resolver

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,32 @@
 # Scanner Development Log
 
+## Day 8 — Hugging Face resolver — 2026-04-28
+
+Branch: `feat/aibom-day8-hf-resolver`
+
+### What shipped
+- `providers/hf_resolver.go` — full HF resolver implementation. `oxvault scan hf:org/model[@revision]` now downloads relevant files to a per-(org, model, rev) cache directory and returns a `ResolvedPackage` with `Kind=KindModelDirectory` so the AIBOM composer can scan it like any other model dir.
+- `parseHFTarget` — handles `hf:org/model` and `hf:org/model@revision`, validates org/model/revision shape, rejects path-traversal (`..`) in revision.
+- `HFConfig` struct with functional options: `WithHFConfig`, `WithHFToken`, `WithHFRevision`, `WithHFCacheDir`, `WithHFMaxFileBytes`, `WithHFMaxCacheBytes`, `WithHFBaseURL`, `WithHFHTTPClient`. Tests inject an `httptest.Server` via `WithHFBaseURL`.
+- HTTP client: 30s timeout, 3 retries with exponential backoff on 5xx, `Retry-After`-aware on 429, clear 401/403/404 errors mentioning `HF_TOKEN`.
+- Filename filtering: only security-relevant files are downloaded (`.pkl`, `.pt`, `.pth`, `.bin`, `.ckpt`, `.onnx`, `.safetensors`, `.md`, `.sigstore`, `.sig`, plus exact basenames `model_signing.json`, `manifest.json`, `config.json`, `readme.md`, `model_card.md`, `model_card.yaml`, `.modelcard.yaml`).
+- Per-file size cap (default 4 GiB) and total-cache size cap (default 16 GiB). Cache hit shortcut via HEAD size check — no re-download when local file size matches remote.
+- Atomic temp+rename writes so a partial download never lands in cache.
+- `config/config.go`: new `HF` section with env-var defaults (`HF_TOKEN`).
+- `cmd/main.go`: `--hf-token`, `--hf-revision`, `--hf-cache-dir`, `--hf-max-file-bytes`, `--hf-max-cache-bytes` flags on `scanCmd`.
+- `app/app.go`: `InitProviders` constructs the resolver via `NewResolverWithOptions(...)` with `HFConfig` flowed from `a.Config.HF`.
+
+### Tests
+- `parseHFTarget` table tests cover all parse paths.
+- `httptest.Server` integration tests: success path, cache hit, 401 (HF_TOKEN hint), 404, 5xx retry-and-succeed. No real HF calls.
+
+### Quality gates
+- `make build` — clean
+- `make test` — all 4 packages pass
+- `make lint` — 0 issues
+
+---
+
 ## Day 7 — Signature verifier — 2026-04-27
 
 Branch: `feat/aibom-day7-signature`

--- a/app/app.go
+++ b/app/app.go
@@ -146,7 +146,15 @@ func (a *App) Initialize() error {
 // InitProviders creates all provider instances (lazy — skips if already set via options)
 func (a *App) InitProviders() error {
 	if a.resolver == nil {
-		a.resolver = providers.NewResolver(a.Logger)
+		a.resolver = providers.NewResolverWithOptions(a.Logger,
+			providers.WithHFConfig(providers.HFConfig{
+				Token:         a.Config.HF.Token,
+				Revision:      a.Config.HF.Revision,
+				CacheDir:      a.Config.HF.CacheDir,
+				MaxFileBytes:  a.Config.HF.MaxFileBytes,
+				MaxCacheBytes: a.Config.HF.MaxCacheBytes,
+			}),
+		)
 	}
 	if a.mcpClient == nil {
 		a.mcpClient = providers.NewMCPClient(a.Logger)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -118,6 +118,13 @@ func newScanCmd() *cobra.Command {
 		noColor        bool
 		configPath     string
 		showSuppressed bool
+
+		// HF (v0.4 AIBOM)
+		hfToken         string
+		hfRevision      string
+		hfCacheDir      string
+		hfMaxFileBytes  int64
+		hfMaxCacheBytes int64
 	)
 
 	cmd := &cobra.Command{
@@ -149,6 +156,23 @@ Config-based scanning:
 			cfg.ProbeNetwork = probeNetwork
 			cfg.NoColor = noColor
 			cfg.ShowSuppressed = showSuppressed
+
+			// HF resolver options (v0.4 AIBOM)
+			if hfToken != "" {
+				cfg.HF.Token = hfToken
+			}
+			if hfRevision != "" {
+				cfg.HF.Revision = hfRevision
+			}
+			if hfCacheDir != "" {
+				cfg.HF.CacheDir = hfCacheDir
+			}
+			if hfMaxFileBytes > 0 {
+				cfg.HF.MaxFileBytes = hfMaxFileBytes
+			}
+			if hfMaxCacheBytes > 0 {
+				cfg.HF.MaxCacheBytes = hfMaxCacheBytes
+			}
 
 			// Apply no-color globally before any output
 			if noColor || cfg.OutputFormat != providers.FormatTerminal {
@@ -191,6 +215,13 @@ Config-based scanning:
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output (for CI or piping)")
 	cmd.Flags().StringVar(&configPath, "config", "", "MCP client config file to scan (path or \"auto\")")
 	cmd.Flags().BoolVar(&showSuppressed, "show-suppressed", false, "Print suppressed findings in a separate section")
+
+	// HF resolver flags (v0.4 AIBOM)
+	cmd.Flags().StringVar(&hfToken, "hf-token", "", "Hugging Face API token (env: HF_TOKEN)")
+	cmd.Flags().StringVar(&hfRevision, "hf-revision", "", "Hugging Face revision/branch/SHA (default: main)")
+	cmd.Flags().StringVar(&hfCacheDir, "hf-cache-dir", "", "Hugging Face cache directory (default: ~/.cache/oxvault/hf)")
+	cmd.Flags().Int64Var(&hfMaxFileBytes, "hf-max-file-bytes", 0, "Max bytes per HF file (default: 4 GiB)")
+	cmd.Flags().Int64Var(&hfMaxCacheBytes, "hf-max-cache-bytes", 0, "Max total HF cache bytes (default: 16 GiB)")
 
 	return cmd
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,19 @@ type Config struct {
 	SkipEgress     bool
 	ProbeNetwork   bool // Run runtime network probe after static scan
 	ShowSuppressed bool // Print suppressed findings in a separate section
+
+	// Hugging Face resolver (v0.4 AIBOM)
+	HF HFOptions
+}
+
+// HFOptions configure the Hugging Face resolver. All fields are optional —
+// providers.HFConfig.applyDefaults() fills in sensible values.
+type HFOptions struct {
+	Token         string // HF_TOKEN env override; empty = anonymous
+	Revision      string // default: "main"
+	CacheDir      string // default: ~/.cache/oxvault/hf
+	MaxFileBytes  int64  // default: 4 GiB
+	MaxCacheBytes int64  // default: 16 GiB
 }
 
 // DefaultConfig returns a Config with sensible defaults
@@ -32,6 +45,10 @@ func DefaultConfig() *Config {
 		OutputFormat: providers.FormatTerminal,
 		FailOn:       providers.RiskTierCritical.String(),
 		PinDir:       defaultPinDir(),
+		HF: HFOptions{
+			Token:    os.Getenv("HF_TOKEN"),
+			Revision: "main",
+		},
 	}
 }
 

--- a/providers/hf_resolver.go
+++ b/providers/hf_resolver.go
@@ -11,9 +11,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/oxvault/scanner/internal/version"
 )
 
 // Hugging Face resolver.
@@ -72,7 +75,20 @@ const (
 	// few KiB — anything beyond 8 MiB is either a hostile host or a runaway
 	// repo we should not be enumerating client-side.
 	hfMaxManifestBytes int64 = 8 * 1024 * 1024
+
+	// hfMaxRedirects bounds the number of HTTP redirects we follow on any
+	// single request. Stdlib's default is 10 — we tighten this to 5 because
+	// the HF CDN chain is at most 2 hops in practice.
+	hfMaxRedirects = 5
 )
+
+// hfHostAllowlist enumerates the hostnames our default HTTP client trusts to
+// receive an Authorization header on a redirect. Anything outside this list
+// has the bearer stripped before the redirected request is sent.
+var hfHostAllowlist = map[string]bool{
+	"huggingface.co":         true,
+	"cdn-lfs.huggingface.co": true,
+}
 
 // ── filtering ───────────────────────────────────────────────────────────────
 
@@ -131,9 +147,62 @@ func (t hfTarget) String() string {
 	return t.Org + "/" + t.Model
 }
 
+// hfNameRegex matches the shape Hugging Face actually allows for org / model
+// segments: alphanumerics plus `.`, `_`, `-`, with a leading and trailing
+// alphanumeric (no leading/trailing dot, no double dots, no separators).
+//
+// This is intentionally stricter than HF's full regex — we reject anything
+// the cache layer would have to special-case (`..`, `.`, leading dot) so the
+// path joiner can never escape the cache root.
+var hfNameRegex = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$`)
+
+// hfRevisionRegex matches the shape we accept for a revision: alphanumerics
+// plus `.`, `_`, `-`. Branch names, tags, and commit SHAs all fit this
+// allowlist.
+var hfRevisionRegex = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// validateHFNameSegment enforces the org/model allowlist and rejects shapes
+// that would let an attacker climb out of the cache root via the path
+// joiner (`..`, leading `.`, embedded separators, control chars).
+func validateHFNameSegment(kind, value string) error {
+	if value == "" {
+		return fmt.Errorf("hf %s is empty", kind)
+	}
+	// Explicit reject for the obvious traversal shapes BEFORE the regex,
+	// so the error message names the actual offence instead of a generic
+	// "invalid character" message.
+	if value == "." || value == ".." || strings.HasPrefix(value, ".") {
+		return fmt.Errorf("hf %s must not start with '.' (got %q)", kind, value)
+	}
+	if !hfNameRegex.MatchString(value) {
+		return fmt.Errorf("hf %s contains invalid characters (got %q)", kind, value)
+	}
+	return nil
+}
+
+// validateHFRevision enforces the revision allowlist.
+func validateHFRevision(rev string) error {
+	if rev == "" {
+		return errors.New("hf revision is empty")
+	}
+	if rev == "." || rev == ".." {
+		return fmt.Errorf("hf revision must not be %q", rev)
+	}
+	if !hfRevisionRegex.MatchString(rev) {
+		return fmt.Errorf("hf revision contains invalid characters (got %q)", rev)
+	}
+	return nil
+}
+
 // parseHFTarget parses an `hf:org/model[@revision]` string. The leading `hf:`
 // prefix is required; the revision is optional and defaults to defaultRevision
 // (which is itself defaulted to DefaultHFRevision when empty).
+//
+// Org, model, and revision are validated against an allowlist regex — the
+// resolver materialises files under `cacheDir/org/model/rev/...`, so any
+// shape that could climb out of that root (`..`, leading `.`, separators,
+// control characters) is rejected here. This is the single chokepoint for
+// cache-traversal hardening.
 func parseHFTarget(target, defaultRevision string) (hfTarget, error) {
 	const prefix = "hf:"
 	if !strings.HasPrefix(target, prefix) {
@@ -154,9 +223,6 @@ func parseHFTarget(target, defaultRevision string) (hfTarget, error) {
 		if strings.TrimSpace(revision) == "" {
 			return hfTarget{}, fmt.Errorf("hf target has empty revision after '@' (target=%q)", target)
 		}
-		if strings.ContainsAny(revision, "/\\") {
-			return hfTarget{}, fmt.Errorf("hf revision must not contain path separators (revision=%q)", revision)
-		}
 	}
 
 	parts := strings.Split(body, "/")
@@ -165,11 +231,14 @@ func parseHFTarget(target, defaultRevision string) (hfTarget, error) {
 	}
 	org := strings.TrimSpace(parts[0])
 	model := strings.TrimSpace(parts[1])
-	if org == "" || model == "" {
-		return hfTarget{}, fmt.Errorf("hf target has empty org or model (target=%q)", target)
+	if err := validateHFNameSegment("org", org); err != nil {
+		return hfTarget{}, fmt.Errorf("hf target invalid (target=%q): %w", target, err)
 	}
-	if strings.ContainsAny(org, "\\") || strings.ContainsAny(model, "\\") {
-		return hfTarget{}, fmt.Errorf("hf target must not contain backslashes (target=%q)", target)
+	if err := validateHFNameSegment("model", model); err != nil {
+		return hfTarget{}, fmt.Errorf("hf target invalid (target=%q): %w", target, err)
+	}
+	if err := validateHFRevision(revision); err != nil {
+		return hfTarget{}, fmt.Errorf("hf target invalid (target=%q): %w", target, err)
 	}
 	return hfTarget{Org: org, Model: model, Revision: revision}, nil
 }
@@ -212,6 +281,26 @@ type HFConfig struct {
 	HTTPClient *http.Client
 }
 
+// LogValue redacts the bearer token before slog records the config. Without
+// this, a `logger.Debug("config", "hf", cfg)` call would emit the token in
+// plaintext to whatever sink the operator wired up. We keep the boolean
+// presence so it's still useful for triage ("did the operator forget to
+// pass --hf-token?").
+func (c HFConfig) LogValue() slog.Value {
+	tokenStatus := "<unset>"
+	if c.Token != "" {
+		tokenStatus = "<set>"
+	}
+	return slog.GroupValue(
+		slog.String("token", tokenStatus),
+		slog.String("revision", c.Revision),
+		slog.String("cache_dir", c.CacheDir),
+		slog.Int64("max_file_bytes", c.MaxFileBytes),
+		slog.Int64("max_cache_bytes", c.MaxCacheBytes),
+		slog.String("base_url", c.BaseURL),
+	)
+}
+
 // applyDefaults fills in unset fields with sensible defaults.
 func (c *HFConfig) applyDefaults() {
 	if c.Revision == "" {
@@ -230,7 +319,65 @@ func (c *HFConfig) applyDefaults() {
 		c.BaseURL = DefaultHFBaseURL
 	}
 	if c.HTTPClient == nil {
-		c.HTTPClient = &http.Client{Timeout: hfHTTPTimeout}
+		c.HTTPClient = newHFHTTPClient(c.BaseURL)
+	} else {
+		// Always wrap user-supplied clients so they get the same redirect
+		// hardening as our default. Repeated wraps are idempotent — the
+		// CheckRedirect we install names itself with a sentinel and is
+		// preserved on subsequent calls.
+		hardenHFClient(c.HTTPClient, c.BaseURL)
+	}
+}
+
+// newHFHTTPClient builds the default HTTP client used by the HF resolver.
+// The client has the standard timeout AND a CheckRedirect that strips the
+// Authorization header when redirecting to an off-allowlist host AND bounds
+// the redirect chain to hfMaxRedirects.
+func newHFHTTPClient(baseURL string) *http.Client {
+	c := &http.Client{Timeout: hfHTTPTimeout}
+	hardenHFClient(c, baseURL)
+	return c
+}
+
+// hardenHFClient installs our standard CheckRedirect on c. Idempotent.
+//
+// Defence-in-depth on top of stdlib's implicit auth-stripping:
+//
+//   - Stdlib already strips Authorization on cross-host redirects, but only
+//     for the literal `Authorization` header — anything we add later (e.g. a
+//     custom token header) would leak. We always re-strip and re-add inside
+//     CheckRedirect, so the policy is enforced regardless of header naming.
+//   - Stdlib's default redirect cap is 10. We tighten to hfMaxRedirects.
+//   - For HF (BaseURL == DefaultHFBaseURL) we re-add Authorization only when
+//     the redirect target is on hfHostAllowlist, so legitimate hf.co → cdn-
+//     lfs.hf.co hops keep working.
+func hardenHFClient(c *http.Client, baseURL string) {
+	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= hfMaxRedirects {
+			return fmt.Errorf("hf: stopped after %d redirects", hfMaxRedirects)
+		}
+		// Strip Authorization unconditionally — stdlib already does this on
+		// cross-host but we want a single defensive policy.
+		req.Header.Del("Authorization")
+
+		// Only re-add the bearer for the production HF host. Tests use
+		// httptest.Server URLs that won't match the allowlist, so they
+		// already exercise the no-auth path.
+		if baseURL != DefaultHFBaseURL {
+			return nil
+		}
+		host := strings.ToLower(req.URL.Hostname())
+		if !hfHostAllowlist[host] {
+			return nil
+		}
+		// Re-add Authorization from the original request's header, if any.
+		// `via` is ordered oldest→newest; the original is via[0].
+		if len(via) > 0 {
+			if auth := via[0].Header.Get("Authorization"); auth != "" {
+				req.Header.Set("Authorization", auth)
+			}
+		}
+		return nil
 	}
 }
 
@@ -307,7 +454,20 @@ func NewResolverWithOptions(logger *slog.Logger, opts ...ResolverOption) Resolve
 
 // resolveHuggingFaceImpl materialises the target HF repo's relevant files
 // under a cache dir and returns a ResolvedPackage pointing at it.
-func (r *resolver) resolveHuggingFaceImpl(target string) (*ResolvedPackage, error) {
+//
+// The named return + deferred recover() is load-bearing: a hostile manifest
+// or a corrupt cache file must NEVER take down the scanner. Without the
+// named return, an explicit `return ...` would have already evaluated by
+// the time the recover runs, causing the panic to be silently swallowed
+// (same lesson learned in Day 5 onnx, Day 6 modelcard, Day 7 signature).
+func (r *resolver) resolveHuggingFaceImpl(target string) (pkg *ResolvedPackage, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			pkg = nil
+			err = fmt.Errorf("hf resolve panic: %v", rec)
+		}
+	}()
+
 	hfCfg := r.hf // local copy so applyDefaults doesn't mutate the resolver
 	hfCfg.applyDefaults()
 
@@ -321,10 +481,25 @@ func (r *resolver) resolveHuggingFaceImpl(target string) (*ResolvedPackage, erro
 		"revision", parsed.Revision,
 	)
 
-	cacheDir := filepath.Join(hfCfg.CacheDir, parsed.Org, parsed.Model, parsed.Revision)
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return nil, fmt.Errorf("hf cache mkdir %s: %w", cacheDir, err)
+	// Open the cache root via os.Root so all subsequent file operations are
+	// guaranteed to stay inside it — symlinks pointing outside the root are
+	// rejected by the OS, not by our string sanitisation. Go 1.25 feature.
+	if err := os.MkdirAll(hfCfg.CacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("hf cache mkdir %s: %w", hfCfg.CacheDir, err)
 	}
+	root, err := os.OpenRoot(hfCfg.CacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("hf cache open root %s: %w", hfCfg.CacheDir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	// Per-target subdir: org/model/revision. parseHFTarget already validates
+	// these segments, so MkdirAll under root is safe.
+	cacheRel := filepath.Join(parsed.Org, parsed.Model, parsed.Revision)
+	if err := root.MkdirAll(cacheRel, 0o755); err != nil {
+		return nil, fmt.Errorf("hf cache mkdir %s: %w", cacheRel, err)
+	}
+	cacheDir := filepath.Join(hfCfg.CacheDir, cacheRel)
 
 	ctx := context.Background()
 
@@ -361,8 +536,11 @@ func (r *resolver) resolveHuggingFaceImpl(target string) (*ResolvedPackage, erro
 
 	var totalBytes int64
 	for _, rel := range relevant {
-		dest := filepath.Join(cacheDir, filepath.FromSlash(rel))
-		fileSize, err := r.fetchHFFile(ctx, hfCfg, parsed, rel, dest, totalBytes)
+		// File destination is relative to the os.Root. The combination of
+		// isSafeRelPath above + os.Root's symlink-escape protection here
+		// gives us defence-in-depth against cache traversal.
+		destRel := filepath.Join(cacheRel, filepath.FromSlash(rel))
+		fileSize, err := r.fetchHFFile(ctx, hfCfg, parsed, rel, root, destRel, totalBytes)
 		if err != nil {
 			return nil, fmt.Errorf("hf download %s: %w", rel, err)
 		}
@@ -416,11 +594,15 @@ func (r *resolver) fetchHFManifest(ctx context.Context, cfg HFConfig, t hfTarget
 	return &manifest, nil
 }
 
-// fetchHFFile downloads a single sibling to dest. Returns bytes written.
-// Idempotent: if dest already exists with matching size, the download is
-// skipped. totalSoFar is the cumulative bytes downloaded before this file
-// — the function errors out if the next download would exceed the cap.
-func (r *resolver) fetchHFFile(ctx context.Context, cfg HFConfig, t hfTarget, rel, dest string, totalSoFar int64) (int64, error) {
+// fetchHFFile downloads a single sibling to the given root-relative dest.
+// Returns bytes written. Idempotent: if dest already exists with matching
+// size, the download is skipped — UNLESS the server omitted Content-Length,
+// in which case we always re-download (the alternative is trusting a cached
+// file we can't validate, which closes the pre-seeded cache attack).
+//
+// totalSoFar is the cumulative bytes downloaded before this file — the
+// function errors out if the next download would exceed the cache cap.
+func (r *resolver) fetchHFFile(ctx context.Context, cfg HFConfig, t hfTarget, rel string, root *os.Root, destRel string, totalSoFar int64) (int64, error) {
 	endpoint, err := url.JoinPath(cfg.BaseURL, t.Org, t.Model, "resolve", t.Revision, rel)
 	if err != nil {
 		return 0, fmt.Errorf("build file url: %w", err)
@@ -447,16 +629,26 @@ func (r *resolver) fetchHFFile(ctx context.Context, cfg HFConfig, t hfTarget, re
 		)
 	}
 
-	if info, err := os.Stat(dest); err == nil && !info.IsDir() && (remoteSize <= 0 || info.Size() == remoteSize) {
-		r.logger.Debug("hf: cache hit",
-			"rfilename", rel,
-			"size", info.Size(),
-		)
-		return info.Size(), nil
+	// Cache hit only when the server gave us a positive Content-Length AND
+	// the on-disk size matches. When Content-Length is absent (remoteSize
+	// <= 0), we cannot validate the cached file, so we MUST force a re-
+	// download — otherwise an attacker who pre-seeded the cache could keep
+	// stale/malicious bytes there indefinitely.
+	if remoteSize > 0 {
+		if info, err := root.Stat(destRel); err == nil && !info.IsDir() && info.Size() == remoteSize {
+			r.logger.Debug("hf: cache hit",
+				"rfilename", rel,
+				"size", info.Size(),
+			)
+			return info.Size(), nil
+		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return 0, fmt.Errorf("mkdir for %s: %w", rel, err)
+	// Make sure the destination's parent dir exists inside the root.
+	if parent := filepath.Dir(destRel); parent != "" && parent != "." {
+		if err := root.MkdirAll(parent, 0o755); err != nil {
+			return 0, fmt.Errorf("mkdir for %s: %w", rel, err)
+		}
 	}
 
 	body, err := r.doHFRequest(ctx, cfg, http.MethodGet, endpoint, t)
@@ -465,43 +657,49 @@ func (r *resolver) fetchHFFile(ctx context.Context, cfg HFConfig, t hfTarget, re
 	}
 	defer func() { _ = body.Close() }()
 
-	tmp, err := os.CreateTemp(filepath.Dir(dest), ".oxvault-hf-*")
+	// Stream into a temp file alongside the destination so a crashed
+	// download never leaves a half-written file in cache.
+	tmpRel := destRel + ".oxvault-hf-tmp"
+	tmp, err := root.OpenFile(tmpRel, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return 0, fmt.Errorf("create temp file: %w", err)
 	}
-	tmpName := tmp.Name()
 	cleanup := func() {
 		_ = tmp.Close()
-		_ = os.Remove(tmpName)
+		_ = root.Remove(tmpRel)
 	}
 
-	cap := cfg.MaxFileBytes
-	if cap <= 0 {
-		cap = DefaultHFMaxFileBytes
+	fileCap := cfg.MaxFileBytes
+	if fileCap <= 0 {
+		fileCap = DefaultHFMaxFileBytes
 	}
-	limited := io.LimitReader(body, cap+1)
+	limited := io.LimitReader(body, fileCap+1)
 	written, err := io.Copy(tmp, limited)
 	if err != nil {
 		cleanup()
 		return 0, fmt.Errorf("write %s: %w", rel, err)
 	}
-	if written > cap {
+	if written > fileCap {
 		cleanup()
-		return 0, fmt.Errorf("file %s exceeds per-file safety cap of %d bytes", rel, cap)
+		return 0, fmt.Errorf("file %s exceeds per-file safety cap of %d bytes", rel, fileCap)
 	}
 	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
+		_ = root.Remove(tmpRel)
 		return 0, fmt.Errorf("close temp file: %w", err)
 	}
-	if err := os.Rename(tmpName, dest); err != nil {
-		_ = os.Remove(tmpName)
-		return 0, fmt.Errorf("rename to %s: %w", dest, err)
+	if err := root.Rename(tmpRel, destRel); err != nil {
+		_ = root.Remove(tmpRel)
+		return 0, fmt.Errorf("rename to %s: %w", destRel, err)
 	}
 	return written, nil
 }
 
 // headHFFile issues a HEAD request and returns the declared Content-Length.
-// Returns 0 (not an error) when the server omits Content-Length.
+//
+// Returns 0 (not an error) when the server omits or malforms Content-Length,
+// but logs each case distinctly so operators can tell "header absent" (debug)
+// from "header malformed" (warn) — the latter signals a buggy or hostile
+// server we want to flag.
 func (r *resolver) headHFFile(ctx context.Context, cfg HFConfig, endpoint string, t hfTarget) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, endpoint, nil)
 	if err != nil {
@@ -520,10 +718,32 @@ func (r *resolver) headHFFile(ctx context.Context, cfg HFConfig, endpoint string
 
 	cl := resp.Header.Get("Content-Length")
 	if cl == "" {
+		// Header genuinely absent — common for chunked-transfer responses.
+		// Not a security event on its own; the caller already forces a
+		// re-download in this case.
+		r.logger.Debug("hf: HEAD response has no Content-Length",
+			"endpoint", endpoint,
+		)
 		return 0, nil
 	}
-	n, err := strconv.ParseInt(cl, 10, 64)
-	if err != nil || n < 0 {
+	n, err := strconv.ParseInt(strings.TrimSpace(cl), 10, 64)
+	if err != nil {
+		// Malformed header — not parseable as int64. Surface as a warning
+		// because a well-behaved server should never emit this.
+		r.logger.Warn("hf: HEAD response Content-Length is not a valid integer",
+			"endpoint", endpoint,
+			"value", cl,
+			"err", err,
+		)
+		return 0, nil
+	}
+	if n < 0 {
+		// Negative length — explicitly hostile or buggy server. Warn so
+		// the operator notices.
+		r.logger.Warn("hf: HEAD response Content-Length is negative",
+			"endpoint", endpoint,
+			"value", n,
+		)
 		return 0, nil
 	}
 	return n, nil
@@ -667,12 +887,26 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	}
 }
 
-// hfUserAgent returns the User-Agent used on every HF request.
+// hfUserAgent returns the User-Agent used on every HF request. The version
+// comes from internal/version so a single ldflags override at build time
+// reflects everywhere the scanner identifies itself.
 func hfUserAgent() string {
-	return "oxvault-scanner/0.4 (+https://oxvault.dev)"
+	return fmt.Sprintf("oxvault-scanner/%s (+https://oxvault.dev)", version.Version)
 }
 
 // isSafeRelPath returns true when rel does not escape the cache dir.
+//
+// Defence-in-depth on top of os.Root: even though os.Root prevents symlink
+// escapes at OS level, this check rejects manifestly hostile rfilename
+// values (`..`, absolute paths, path-traversal segments) before we even
+// open a file handle. Belt and braces.
+//
+// We deliberately reject ANY `..` segment in the input, even one that
+// `filepath.Clean` would normalise to a path inside the root (e.g.
+// `foo/../bar` cleans to `bar`). A manifest from upstream should never
+// have a reason to encode literal `..` — its presence is a strong
+// signal of either bug or attack, and silently cleaning it would let
+// future refactors miss the traversal.
 func isSafeRelPath(rel string) bool {
 	if rel == "" {
 		return false
@@ -680,7 +914,16 @@ func isSafeRelPath(rel string) bool {
 	if strings.HasPrefix(rel, "/") || strings.HasPrefix(rel, "\\") {
 		return false
 	}
-	cleaned := filepath.ToSlash(filepath.Clean(rel))
+	// Normalise both Unix and Windows separators so we catch
+	// `..\\windows\\system32` too.
+	normalised := strings.ReplaceAll(rel, "\\", "/")
+	// Reject literal `..` segments BEFORE Clean rewrites them.
+	for _, seg := range strings.Split(normalised, "/") {
+		if seg == ".." {
+			return false
+		}
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(normalised))
 	if cleaned == "." || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
 		return false
 	}

--- a/providers/hf_resolver.go
+++ b/providers/hf_resolver.go
@@ -1,0 +1,693 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Hugging Face resolver.
+//
+// Resolves `hf:org/model[@revision]` targets by:
+//
+//  1. Parsing the target into (org, model, revision). Default revision is "main".
+//  2. Calling the HF API manifest endpoint to enumerate the repo's siblings.
+//  3. Filtering siblings to security-relevant files only (model artifacts,
+//     model cards, signatures, common config / manifest files).
+//  4. Downloading each filtered file under a per-(org, model, rev) cache
+//     directory rooted at `~/.cache/oxvault/hf/`. Idempotent: existing files
+//     with matching size are skipped.
+//  5. Returning a `ResolvedPackage` with `Kind=KindModelDirectory` so the
+//     AIBOM composer can scan the cache directory like any other model dir.
+//
+// Layer rule: this file lives in providers/ and depends on patterns/ + stdlib
+// only. No HF SDK, no third-party HTTP libraries. Pure `net/http`.
+//
+// HTTP base URL is overridable via `WithHFBaseURL` so tests can swap in an
+// `httptest.Server` — the production default is `https://huggingface.co`.
+
+// ── constants ───────────────────────────────────────────────────────────────
+
+const (
+	// DefaultHFBaseURL is the production Hugging Face host. Tests override via
+	// WithHFBaseURL pointing at an httptest.Server.
+	DefaultHFBaseURL = "https://huggingface.co"
+
+	// DefaultHFRevision is the default branch name when the target does not
+	// specify one with `@revision`.
+	DefaultHFRevision = "main"
+
+	// DefaultHFMaxFileBytes is the default per-file safety cap. Files whose
+	// declared size exceeds this are skipped (with a logged warning) — set
+	// large because real model checkpoints commonly exceed 1 GiB.
+	DefaultHFMaxFileBytes int64 = 4 * 1024 * 1024 * 1024 // 4 GiB
+
+	// DefaultHFMaxCacheBytes is the default total-cache safety cap. The
+	// resolver errors out before exceeding this — it does NOT silently
+	// truncate, since a partial download would mislead the AIBOM composer.
+	DefaultHFMaxCacheBytes int64 = 16 * 1024 * 1024 * 1024 // 16 GiB
+
+	// hfHTTPTimeout is the per-request timeout for HF API + file downloads.
+	hfHTTPTimeout = 30 * time.Second
+
+	// hfMaxRetries is the max number of retries on 5xx and timeout errors.
+	// 3 retries after the initial = 4 total attempts.
+	hfMaxRetries = 3
+
+	// hfRetryBaseDelay is the base delay for exponential backoff. Each retry
+	// waits hfRetryBaseDelay * 2^attempt.
+	hfRetryBaseDelay = 500 * time.Millisecond
+
+	// hfMaxManifestBytes caps the manifest JSON body. Real HF manifests are a
+	// few KiB — anything beyond 8 MiB is either a hostile host or a runaway
+	// repo we should not be enumerating client-side.
+	hfMaxManifestBytes int64 = 8 * 1024 * 1024
+)
+
+// ── filtering ───────────────────────────────────────────────────────────────
+
+// hfRelevantExtensions enumerates file extensions whose contents are scanned
+// by the AIBOM module. Anything outside this set is ignored to keep the cache
+// small and the download time bounded.
+var hfRelevantExtensions = map[string]bool{
+	".pkl":         true,
+	".pickle":      true,
+	".pt":          true,
+	".pth":         true,
+	".bin":         true,
+	".ckpt":        true,
+	".onnx":        true,
+	".safetensors": true,
+	".md":          true,
+	".sigstore":    true,
+	".sig":         true,
+}
+
+// hfRelevantBasenames enumerates exact basenames worth fetching even when the
+// extension alone is uninformative (`config.json`, `manifest.json`). Match is
+// case-insensitive — the resolver lowercases before lookup.
+var hfRelevantBasenames = map[string]bool{
+	"model_signing.json": true,
+	"manifest.json":      true,
+	"config.json":        true,
+	"readme.md":          true,
+	"model_card.md":      true,
+	"model_card.yaml":    true,
+	".modelcard.yaml":    true,
+}
+
+// isHFRelevantFile returns true when the file is worth downloading for AIBOM
+// analysis.
+func isHFRelevantFile(rfilename string) bool {
+	base := strings.ToLower(filepath.Base(rfilename))
+	if hfRelevantBasenames[base] {
+		return true
+	}
+	ext := strings.ToLower(filepath.Ext(rfilename))
+	return hfRelevantExtensions[ext]
+}
+
+// ── target parsing ──────────────────────────────────────────────────────────
+
+// hfTarget is the parsed shape of an `hf:org/model[@revision]` target.
+type hfTarget struct {
+	Org      string
+	Model    string
+	Revision string
+}
+
+// String returns the canonical "org/model" form used for ResolvedPackage.Name.
+func (t hfTarget) String() string {
+	return t.Org + "/" + t.Model
+}
+
+// parseHFTarget parses an `hf:org/model[@revision]` string. The leading `hf:`
+// prefix is required; the revision is optional and defaults to defaultRevision
+// (which is itself defaulted to DefaultHFRevision when empty).
+func parseHFTarget(target, defaultRevision string) (hfTarget, error) {
+	const prefix = "hf:"
+	if !strings.HasPrefix(target, prefix) {
+		return hfTarget{}, fmt.Errorf("hf target must start with %q (got %q)", prefix, target)
+	}
+	body := strings.TrimPrefix(target, prefix)
+	if body == "" {
+		return hfTarget{}, fmt.Errorf("hf target is empty after %q prefix", prefix)
+	}
+
+	revision := defaultRevision
+	if revision == "" {
+		revision = DefaultHFRevision
+	}
+	if at := strings.LastIndex(body, "@"); at != -1 {
+		revision = body[at+1:]
+		body = body[:at]
+		if strings.TrimSpace(revision) == "" {
+			return hfTarget{}, fmt.Errorf("hf target has empty revision after '@' (target=%q)", target)
+		}
+		if strings.ContainsAny(revision, "/\\") {
+			return hfTarget{}, fmt.Errorf("hf revision must not contain path separators (revision=%q)", revision)
+		}
+	}
+
+	parts := strings.Split(body, "/")
+	if len(parts) != 2 {
+		return hfTarget{}, fmt.Errorf("hf target must be of the form 'org/model[@revision]' (got %q)", target)
+	}
+	org := strings.TrimSpace(parts[0])
+	model := strings.TrimSpace(parts[1])
+	if org == "" || model == "" {
+		return hfTarget{}, fmt.Errorf("hf target has empty org or model (target=%q)", target)
+	}
+	if strings.ContainsAny(org, "\\") || strings.ContainsAny(model, "\\") {
+		return hfTarget{}, fmt.Errorf("hf target must not contain backslashes (target=%q)", target)
+	}
+	return hfTarget{Org: org, Model: model, Revision: revision}, nil
+}
+
+// ── manifest types ──────────────────────────────────────────────────────────
+
+// hfManifest mirrors the subset of the HF API model-info response we need.
+type hfManifest struct {
+	Siblings []hfSibling `json:"siblings"`
+}
+
+// hfSibling is a single file entry from the HF manifest.
+type hfSibling struct {
+	Rfilename string `json:"rfilename"`
+}
+
+// ── HF resolver options ─────────────────────────────────────────────────────
+
+// HFConfig captures the runtime configuration for the Hugging Face resolver.
+type HFConfig struct {
+	// Token is the HF API token used as a bearer for gated models.
+	Token string
+
+	// Revision is the default revision used when the target omits one.
+	Revision string
+
+	// CacheDir is the absolute path to the cache root.
+	CacheDir string
+
+	// MaxFileBytes caps the size of a single sibling file.
+	MaxFileBytes int64
+
+	// MaxCacheBytes caps the total cumulative on-disk size for one resolve.
+	MaxCacheBytes int64
+
+	// BaseURL is the HF host. Tests override via WithHFBaseURL.
+	BaseURL string
+
+	// HTTPClient is the HTTP client used for all HF requests.
+	HTTPClient *http.Client
+}
+
+// applyDefaults fills in unset fields with sensible defaults.
+func (c *HFConfig) applyDefaults() {
+	if c.Revision == "" {
+		c.Revision = DefaultHFRevision
+	}
+	if c.CacheDir == "" {
+		c.CacheDir = defaultHFCacheDir()
+	}
+	if c.MaxFileBytes <= 0 {
+		c.MaxFileBytes = DefaultHFMaxFileBytes
+	}
+	if c.MaxCacheBytes <= 0 {
+		c.MaxCacheBytes = DefaultHFMaxCacheBytes
+	}
+	if c.BaseURL == "" {
+		c.BaseURL = DefaultHFBaseURL
+	}
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{Timeout: hfHTTPTimeout}
+	}
+}
+
+// defaultHFCacheDir returns `~/.cache/oxvault/hf`. Falls back to OS temp dir.
+func defaultHFCacheDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".cache", "oxvault", "hf")
+	}
+	return filepath.Join(os.TempDir(), "oxvault-hf-cache")
+}
+
+// ── resolver options for HF ─────────────────────────────────────────────────
+
+// resolverOptions is the set of functional options for the resolver.
+type resolverOptions struct {
+	hf HFConfig
+}
+
+// ResolverOption configures the resolver.
+type ResolverOption func(*resolverOptions)
+
+// WithHFConfig REPLACES the resolver's HFConfig wholesale.
+func WithHFConfig(cfg HFConfig) ResolverOption {
+	return func(o *resolverOptions) { o.hf = cfg }
+}
+
+// WithHFToken sets the HF API token used as a bearer for gated repos.
+func WithHFToken(token string) ResolverOption {
+	return func(o *resolverOptions) { o.hf.Token = token }
+}
+
+// WithHFRevision sets the default revision used when the target omits one.
+func WithHFRevision(rev string) ResolverOption {
+	return func(o *resolverOptions) { o.hf.Revision = rev }
+}
+
+// WithHFCacheDir sets the cache root used to materialise HF repos to disk.
+func WithHFCacheDir(dir string) ResolverOption {
+	return func(o *resolverOptions) { o.hf.CacheDir = dir }
+}
+
+// WithHFMaxFileBytes sets the per-file safety cap.
+func WithHFMaxFileBytes(n int64) ResolverOption {
+	return func(o *resolverOptions) { o.hf.MaxFileBytes = n }
+}
+
+// WithHFMaxCacheBytes sets the total-cache safety cap.
+func WithHFMaxCacheBytes(n int64) ResolverOption {
+	return func(o *resolverOptions) { o.hf.MaxCacheBytes = n }
+}
+
+// WithHFBaseURL sets the HF host. Tests use this to point at httptest.Server.
+func WithHFBaseURL(u string) ResolverOption {
+	return func(o *resolverOptions) { o.hf.BaseURL = u }
+}
+
+// WithHFHTTPClient sets the HTTP client.
+func WithHFHTTPClient(c *http.Client) ResolverOption {
+	return func(o *resolverOptions) { o.hf.HTTPClient = c }
+}
+
+// NewResolverWithOptions constructs a resolver with HF-specific configuration.
+// The plain `NewResolver(logger)` constructor remains the default for call
+// sites that don't need HF wiring.
+func NewResolverWithOptions(logger *slog.Logger, opts ...ResolverOption) Resolver {
+	o := &resolverOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &resolver{logger: logger, hf: o.hf}
+}
+
+// ── resolver implementation ─────────────────────────────────────────────────
+
+// resolveHuggingFaceImpl materialises the target HF repo's relevant files
+// under a cache dir and returns a ResolvedPackage pointing at it.
+func (r *resolver) resolveHuggingFaceImpl(target string) (*ResolvedPackage, error) {
+	hfCfg := r.hf // local copy so applyDefaults doesn't mutate the resolver
+	hfCfg.applyDefaults()
+
+	parsed, err := parseHFTarget(target, hfCfg.Revision)
+	if err != nil {
+		return nil, fmt.Errorf("hf resolve: %w", err)
+	}
+	r.logger.Info("resolving hf target",
+		"org", parsed.Org,
+		"model", parsed.Model,
+		"revision", parsed.Revision,
+	)
+
+	cacheDir := filepath.Join(hfCfg.CacheDir, parsed.Org, parsed.Model, parsed.Revision)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("hf cache mkdir %s: %w", cacheDir, err)
+	}
+
+	ctx := context.Background()
+
+	manifest, err := r.fetchHFManifest(ctx, hfCfg, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("hf manifest: %w", err)
+	}
+
+	// Filter siblings to security-relevant files only.
+	var relevant []string
+	for _, s := range manifest.Siblings {
+		if s.Rfilename == "" {
+			continue
+		}
+		if !isSafeRelPath(s.Rfilename) {
+			r.logger.Warn("hf: skipping unsafe sibling path",
+				"rfilename", s.Rfilename,
+				"target", parsed.String(),
+			)
+			continue
+		}
+		if isHFRelevantFile(s.Rfilename) {
+			relevant = append(relevant, s.Rfilename)
+		}
+	}
+
+	if len(relevant) == 0 {
+		r.logger.Warn("hf: no security-relevant files in repo",
+			"target", parsed.String(),
+			"revision", parsed.Revision,
+			"siblings_total", len(manifest.Siblings),
+		)
+	}
+
+	var totalBytes int64
+	for _, rel := range relevant {
+		dest := filepath.Join(cacheDir, filepath.FromSlash(rel))
+		fileSize, err := r.fetchHFFile(ctx, hfCfg, parsed, rel, dest, totalBytes)
+		if err != nil {
+			return nil, fmt.Errorf("hf download %s: %w", rel, err)
+		}
+		totalBytes += fileSize
+	}
+
+	r.logger.Info("hf resolve complete",
+		"target", parsed.String(),
+		"revision", parsed.Revision,
+		"files", len(relevant),
+		"bytes", totalBytes,
+		"cache", cacheDir,
+	)
+
+	return &ResolvedPackage{
+		Path:    cacheDir,
+		Kind:    KindModelDirectory,
+		Name:    parsed.String(),
+		Version: parsed.Revision,
+	}, nil
+}
+
+// ── HTTP helpers ────────────────────────────────────────────────────────────
+
+// fetchHFManifest calls the HF API model-info endpoint and decodes siblings.
+func (r *resolver) fetchHFManifest(ctx context.Context, cfg HFConfig, t hfTarget) (*hfManifest, error) {
+	endpoint, err := url.JoinPath(cfg.BaseURL, "api", "models", t.Org, t.Model, "revision", t.Revision)
+	if err != nil {
+		return nil, fmt.Errorf("build manifest url: %w", err)
+	}
+
+	body, err := r.doHFRequest(ctx, cfg, http.MethodGet, endpoint, t)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = body.Close() }()
+
+	limited := io.LimitReader(body, hfMaxManifestBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest body: %w", err)
+	}
+	if int64(len(data)) > hfMaxManifestBytes {
+		return nil, fmt.Errorf("hf manifest exceeds %d-byte safety cap", hfMaxManifestBytes)
+	}
+
+	var manifest hfManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest json: %w", err)
+	}
+	return &manifest, nil
+}
+
+// fetchHFFile downloads a single sibling to dest. Returns bytes written.
+// Idempotent: if dest already exists with matching size, the download is
+// skipped. totalSoFar is the cumulative bytes downloaded before this file
+// — the function errors out if the next download would exceed the cap.
+func (r *resolver) fetchHFFile(ctx context.Context, cfg HFConfig, t hfTarget, rel, dest string, totalSoFar int64) (int64, error) {
+	endpoint, err := url.JoinPath(cfg.BaseURL, t.Org, t.Model, "resolve", t.Revision, rel)
+	if err != nil {
+		return 0, fmt.Errorf("build file url: %w", err)
+	}
+
+	remoteSize, err := r.headHFFile(ctx, cfg, endpoint, t)
+	if err != nil {
+		return 0, err
+	}
+
+	if cfg.MaxFileBytes > 0 && remoteSize > cfg.MaxFileBytes {
+		r.logger.Warn("hf: skipping oversized file",
+			"rfilename", rel,
+			"size", remoteSize,
+			"cap", cfg.MaxFileBytes,
+		)
+		return 0, nil
+	}
+
+	if cfg.MaxCacheBytes > 0 && totalSoFar+remoteSize > cfg.MaxCacheBytes {
+		return 0, fmt.Errorf(
+			"total cache size would exceed %d-byte cap (next file %q is %d bytes, current total %d)",
+			cfg.MaxCacheBytes, rel, remoteSize, totalSoFar,
+		)
+	}
+
+	if info, err := os.Stat(dest); err == nil && !info.IsDir() && (remoteSize <= 0 || info.Size() == remoteSize) {
+		r.logger.Debug("hf: cache hit",
+			"rfilename", rel,
+			"size", info.Size(),
+		)
+		return info.Size(), nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return 0, fmt.Errorf("mkdir for %s: %w", rel, err)
+	}
+
+	body, err := r.doHFRequest(ctx, cfg, http.MethodGet, endpoint, t)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = body.Close() }()
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".oxvault-hf-*")
+	if err != nil {
+		return 0, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+
+	cap := cfg.MaxFileBytes
+	if cap <= 0 {
+		cap = DefaultHFMaxFileBytes
+	}
+	limited := io.LimitReader(body, cap+1)
+	written, err := io.Copy(tmp, limited)
+	if err != nil {
+		cleanup()
+		return 0, fmt.Errorf("write %s: %w", rel, err)
+	}
+	if written > cap {
+		cleanup()
+		return 0, fmt.Errorf("file %s exceeds per-file safety cap of %d bytes", rel, cap)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return 0, fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		_ = os.Remove(tmpName)
+		return 0, fmt.Errorf("rename to %s: %w", dest, err)
+	}
+	return written, nil
+}
+
+// headHFFile issues a HEAD request and returns the declared Content-Length.
+// Returns 0 (not an error) when the server omits Content-Length.
+func (r *resolver) headHFFile(ctx context.Context, cfg HFConfig, endpoint string, t hfTarget) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build HEAD request: %w", err)
+	}
+	if cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	}
+	req.Header.Set("User-Agent", hfUserAgent())
+
+	resp, err := r.doHFRoundTrip(cfg, req, t)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	cl := resp.Header.Get("Content-Length")
+	if cl == "" {
+		return 0, nil
+	}
+	n, err := strconv.ParseInt(cl, 10, 64)
+	if err != nil || n < 0 {
+		return 0, nil
+	}
+	return n, nil
+}
+
+// doHFRequest issues a request and returns the response body for streaming.
+func (r *resolver) doHFRequest(ctx context.Context, cfg HFConfig, method, endpoint string, t hfTarget) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build %s request: %w", method, err)
+	}
+	if cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	}
+	req.Header.Set("User-Agent", hfUserAgent())
+	req.Header.Set("Accept", "*/*")
+
+	resp, err := r.doHFRoundTrip(cfg, req, t)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+// doHFRoundTrip executes req with retry on 5xx + Retry-After-aware 429.
+func (r *resolver) doHFRoundTrip(cfg HFConfig, req *http.Request, t hfTarget) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt <= hfMaxRetries; attempt++ {
+		reqClone := req.Clone(req.Context())
+		resp, err := cfg.HTTPClient.Do(reqClone)
+		if err != nil {
+			lastErr = err
+			if attempt < hfMaxRetries && !errors.Is(err, context.Canceled) {
+				if waitErr := sleepWithContext(req.Context(), backoff(attempt)); waitErr != nil {
+					return nil, waitErr
+				}
+				continue
+			}
+			return nil, fmt.Errorf("hf %s %s: %w", req.Method, req.URL.String(), err)
+		}
+
+		switch {
+		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			return resp, nil
+		case resp.StatusCode == http.StatusUnauthorized:
+			drainAndClose(resp)
+			return nil, fmt.Errorf(
+				"hf authentication required for %s/%s (status 401) — set HF_TOKEN or pass --hf-token",
+				t.Org, t.Model,
+			)
+		case resp.StatusCode == http.StatusForbidden:
+			drainAndClose(resp)
+			return nil, fmt.Errorf(
+				"hf access denied for %s/%s (status 403) — gated model? set HF_TOKEN or pass --hf-token, and confirm the account has been granted access",
+				t.Org, t.Model,
+			)
+		case resp.StatusCode == http.StatusNotFound:
+			drainAndClose(resp)
+			return nil, fmt.Errorf(
+				"hf model not found: %s/%s@%s (status 404)",
+				t.Org, t.Model, t.Revision,
+			)
+		case resp.StatusCode == http.StatusTooManyRequests:
+			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			drainAndClose(resp)
+			if attempt >= hfMaxRetries {
+				lastErr = fmt.Errorf("hf rate-limited (status 429) after %d attempts", attempt+1)
+				return nil, lastErr
+			}
+			delay := retryAfter
+			if delay <= 0 {
+				delay = backoff(attempt)
+			}
+			if waitErr := sleepWithContext(req.Context(), delay); waitErr != nil {
+				return nil, waitErr
+			}
+			continue
+		case resp.StatusCode >= 500:
+			drainAndClose(resp)
+			lastErr = fmt.Errorf("hf server error %d on %s", resp.StatusCode, req.URL.String())
+			if attempt >= hfMaxRetries {
+				return nil, lastErr
+			}
+			if waitErr := sleepWithContext(req.Context(), backoff(attempt)); waitErr != nil {
+				return nil, waitErr
+			}
+			continue
+		default:
+			drainAndClose(resp)
+			return nil, fmt.Errorf("hf unexpected status %d on %s", resp.StatusCode, req.URL.String())
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("hf request exhausted retries on %s", req.URL.String())
+	}
+	return nil, lastErr
+}
+
+// drainAndClose drains and closes resp.Body so the underlying connection
+// can be reused.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64*1024))
+	_ = resp.Body.Close()
+}
+
+// backoff returns the delay before the (attempt+1)th retry. Exponential.
+func backoff(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	return hfRetryBaseDelay * (1 << attempt)
+}
+
+// parseRetryAfter parses the Retry-After header per RFC 7231 §7.1.3.
+// Only the seconds form is supported.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
+		return time.Duration(n) * time.Second
+	}
+	return 0
+}
+
+// sleepWithContext waits `d` while honouring ctx.Done().
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// hfUserAgent returns the User-Agent used on every HF request.
+func hfUserAgent() string {
+	return "oxvault-scanner/0.4 (+https://oxvault.dev)"
+}
+
+// isSafeRelPath returns true when rel does not escape the cache dir.
+func isSafeRelPath(rel string) bool {
+	if rel == "" {
+		return false
+	}
+	if strings.HasPrefix(rel, "/") || strings.HasPrefix(rel, "\\") {
+		return false
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(rel))
+	if cleaned == "." || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
+		return false
+	}
+	for _, seg := range strings.Split(cleaned, "/") {
+		if seg == ".." {
+			return false
+		}
+	}
+	return true
+}

--- a/providers/hf_resolver_test.go
+++ b/providers/hf_resolver_test.go
@@ -1,0 +1,266 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── parseHFTarget ──────────────────────────────────────────────────────────
+
+func TestParseHFTarget(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		defRev    string
+		wantErr   bool
+		wantOrg   string
+		wantModel string
+		wantRev   string
+	}{
+		{name: "simple", target: "hf:meta-llama/Llama-3-8B", defRev: "main", wantOrg: "meta-llama", wantModel: "Llama-3-8B", wantRev: "main"},
+		{name: "with revision", target: "hf:org/model@v1.0", defRev: "main", wantOrg: "org", wantModel: "model", wantRev: "v1.0"},
+		{name: "default rev empty -> main", target: "hf:a/b", defRev: "", wantOrg: "a", wantModel: "b", wantRev: "main"},
+		{name: "missing prefix", target: "org/model", wantErr: true},
+		{name: "no slash", target: "hf:nothing", wantErr: true},
+		{name: "empty org", target: "hf:/model", wantErr: true},
+		{name: "empty model", target: "hf:org/", wantErr: true},
+		{name: "path traversal in revision", target: "hf:org/model@../../etc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseHFTarget(tt.target, tt.defRev)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Org != tt.wantOrg || got.Model != tt.wantModel || got.Revision != tt.wantRev {
+				t.Errorf("got (%q, %q, %q), want (%q, %q, %q)",
+					got.Org, got.Model, got.Revision, tt.wantOrg, tt.wantModel, tt.wantRev)
+			}
+		})
+	}
+}
+
+// ── httptest harness ───────────────────────────────────────────────────────
+
+type hfFixture struct {
+	rfilename string
+	body      []byte
+}
+
+func newHFTestServer(t *testing.T, fixtures []hfFixture, opts ...func(*hfServerOpts)) *httptest.Server {
+	t.Helper()
+	cfg := hfServerOpts{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// API manifest path: /api/models/{org}/{model}/revision/{rev}
+		if strings.HasPrefix(r.URL.Path, "/api/models/") {
+			if cfg.manifestStatus != 0 && cfg.manifestStatus != 200 {
+				if cfg.retryAfter != "" {
+					w.Header().Set("Retry-After", cfg.retryAfter)
+				}
+				w.WriteHeader(cfg.manifestStatus)
+				return
+			}
+			siblings := make([]map[string]string, 0, len(fixtures))
+			for _, f := range fixtures {
+				siblings = append(siblings, map[string]string{"rfilename": f.rfilename})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"siblings": siblings})
+			return
+		}
+		// File resolve path: /{org}/{model}/resolve/{rev}/{filename...}
+		for _, f := range fixtures {
+			if strings.HasSuffix(r.URL.Path, "/"+f.rfilename) {
+				if r.Method == http.MethodHead {
+					w.Header().Set("Content-Length", fmt.Sprintf("%d", len(f.body)))
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.Header().Set("Content-Length", fmt.Sprintf("%d", len(f.body)))
+				_, _ = w.Write(f.body)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+type hfServerOpts struct {
+	manifestStatus int
+	retryAfter     string
+}
+
+func withManifestStatus(code int) func(*hfServerOpts) {
+	return func(o *hfServerOpts) { o.manifestStatus = code }
+}
+
+// ── happy path ─────────────────────────────────────────────────────────────
+
+func TestHFResolver_Success(t *testing.T) {
+	fixtures := []hfFixture{
+		{rfilename: "config.json", body: []byte(`{"a":1}`)},
+		{rfilename: "model.safetensors", body: []byte("safetensors-bytes")},
+		{rfilename: "README.md", body: []byte("# model card")},
+		{rfilename: "junk.bin.txt", body: []byte("ignored")},
+	}
+	srv := newHFTestServer(t, fixtures)
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewResolverWithOptions(logger,
+		WithHFBaseURL(srv.URL),
+		WithHFCacheDir(cacheDir),
+	)
+
+	pkg, err := r.Resolve("hf:org/model")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if pkg.Kind != KindModelDirectory {
+		t.Errorf("Kind = %q, want KindModelDirectory", pkg.Kind)
+	}
+	if pkg.Name != "org/model" {
+		t.Errorf("Name = %q", pkg.Name)
+	}
+	// security-relevant files downloaded
+	for _, want := range []string{"config.json", "model.safetensors", "README.md"} {
+		if _, err := os.Stat(filepath.Join(pkg.Path, want)); err != nil {
+			t.Errorf("expected %q in cache: %v", want, err)
+		}
+	}
+	// junk.bin.txt is NOT a security-relevant file (.txt extension)
+	if _, err := os.Stat(filepath.Join(pkg.Path, "junk.bin.txt")); err == nil {
+		t.Error("junk.bin.txt should NOT have been downloaded (not a security artifact)")
+	}
+}
+
+func TestHFResolver_CacheHit(t *testing.T) {
+	fixtures := []hfFixture{
+		{rfilename: "config.json", body: []byte(`{"x":1}`)},
+	}
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/models/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"siblings": []map[string]string{{"rfilename": "config.json"}},
+			})
+			return
+		}
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(fixtures[0].body)))
+			return
+		}
+		hits++
+		_, _ = w.Write(fixtures[0].body)
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewResolverWithOptions(logger, WithHFBaseURL(srv.URL), WithHFCacheDir(cacheDir))
+
+	if _, err := r.Resolve("hf:org/model"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("expected 1 GET, got %d", hits)
+	}
+	// second resolve should hit cache (no GET)
+	if _, err := r.Resolve("hf:org/model"); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("cache miss: expected 1 GET total, got %d", hits)
+	}
+}
+
+// ── error paths ────────────────────────────────────────────────────────────
+
+func TestHFResolver_Unauthorized(t *testing.T) {
+	srv := newHFTestServer(t, nil, withManifestStatus(http.StatusUnauthorized))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewResolverWithOptions(logger, WithHFBaseURL(srv.URL), WithHFCacheDir(t.TempDir()))
+	_, err := r.Resolve("hf:org/model")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "HF_TOKEN") {
+		t.Errorf("expected HF_TOKEN hint, got: %v", err)
+	}
+}
+
+func TestHFResolver_NotFound(t *testing.T) {
+	srv := newHFTestServer(t, nil, withManifestStatus(http.StatusNotFound))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewResolverWithOptions(logger, WithHFBaseURL(srv.URL), WithHFCacheDir(t.TempDir()))
+	_, err := r.Resolve("hf:org/model")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestHFResolver_RetryOn5xx(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/models/") {
+			calls++
+			if calls < 2 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"siblings": []map[string]string{{"rfilename": "config.json"}},
+			})
+			return
+		}
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", "1")
+			return
+		}
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := &http.Client{Timeout: 10 * time.Second}
+	r := NewResolverWithOptions(logger,
+		WithHFBaseURL(srv.URL),
+		WithHFCacheDir(t.TempDir()),
+		WithHFHTTPClient(client),
+	)
+	if _, err := r.Resolve("hf:org/model"); err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if calls < 2 {
+		t.Errorf("expected at least 2 manifest calls, got %d", calls)
+	}
+}

--- a/providers/hf_resolver_test.go
+++ b/providers/hf_resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -34,13 +35,33 @@ func TestParseHFTarget(t *testing.T) {
 		{name: "empty org", target: "hf:/model", wantErr: true},
 		{name: "empty model", target: "hf:org/", wantErr: true},
 		{name: "path traversal in revision", target: "hf:org/model@../../etc", wantErr: true},
+
+		// Cache-traversal hardening — the resolver materialises files under
+		// cacheDir/<org>/<model>/<rev>, so any segment that climbs out of
+		// the cache root must be rejected at parse time.
+		{name: "dotdot org", target: "hf:../foo/model", wantErr: true},
+		{name: "dot org", target: "hf:./foo/model", wantErr: true},
+		{name: "dotdot whole body", target: "hf:../foo", wantErr: true},
+		{name: "dot whole body", target: "hf:./foo", wantErr: true},
+		{name: "leading dot in org", target: "hf:.foo/model", wantErr: true},
+		{name: "leading dot in model", target: "hf:foo/.model", wantErr: true},
+		{name: "trailing dot in org", target: "hf:foo./model", wantErr: true},
+		{name: "control char in org", target: "hf:foo\x00bar/model", wantErr: true},
+		{name: "control char in model", target: "hf:foo/bar\x00baz", wantErr: true},
+		{name: "newline in org", target: "hf:foo\nbar/model", wantErr: true},
+		{name: "space in org", target: "hf:foo bar/model", wantErr: true},
+		{name: "slash in revision rejected", target: "hf:org/model@feat/x", wantErr: true},
+		{name: "backslash in revision rejected", target: "hf:org/model@feat\\x", wantErr: true},
+		{name: "dot revision", target: "hf:org/model@.", wantErr: true},
+		{name: "dotdot revision", target: "hf:org/model@..", wantErr: true},
+		{name: "control char in revision", target: "hf:org/model@v1\x00", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseHFTarget(tt.target, tt.defRev)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatal("expected error")
+					t.Fatalf("expected error, got %+v", got)
 				}
 				return
 			}
@@ -50,6 +71,73 @@ func TestParseHFTarget(t *testing.T) {
 			if got.Org != tt.wantOrg || got.Model != tt.wantModel || got.Revision != tt.wantRev {
 				t.Errorf("got (%q, %q, %q), want (%q, %q, %q)",
 					got.Org, got.Model, got.Revision, tt.wantOrg, tt.wantModel, tt.wantRev)
+			}
+		})
+	}
+}
+
+// ── isSafeRelPath ──────────────────────────────────────────────────────────
+
+func TestIsSafeRelPath(t *testing.T) {
+	tests := []struct {
+		name string
+		rel  string
+		want bool
+	}{
+		{name: "simple file", rel: "config.json", want: true},
+		{name: "nested file", rel: "subdir/config.json", want: true},
+		{name: "dot in name (safe)", rel: "model.safetensors", want: true},
+
+		// All of these must be rejected.
+		{name: "empty", rel: "", want: false},
+		{name: "absolute unix", rel: "/etc/passwd", want: false},
+		{name: "absolute windows", rel: "\\windows\\system32\\sam", want: false},
+		{name: "leading dotdot", rel: "../etc/passwd", want: false},
+		{name: "windows dotdot", rel: "..\\windows\\system32", want: false},
+		{name: "embedded dotdot", rel: "foo/../bar", want: false},
+		{name: "dotdot only", rel: "..", want: false},
+		{name: "dot only", rel: ".", want: false},
+		{name: "trailing dotdot segment", rel: "foo/..", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSafeRelPath(tt.rel)
+			if got != tt.want {
+				t.Errorf("isSafeRelPath(%q) = %v, want %v", tt.rel, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── HFConfig.LogValue redaction ────────────────────────────────────────────
+
+func TestHFConfigLogValueRedactsToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		wantToken string
+	}{
+		{name: "set", token: "hf_secret_value_12345", wantToken: "<set>"},
+		{name: "unset", token: "", wantToken: "<unset>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := HFConfig{
+				Token:    tt.token,
+				Revision: "main",
+				CacheDir: "/tmp/cache",
+				BaseURL:  DefaultHFBaseURL,
+			}
+			buf := &strings.Builder{}
+			logger := slog.New(slog.NewTextHandler(buf, nil))
+			logger.Info("test", "hf", cfg)
+
+			out := buf.String()
+			if !strings.Contains(out, tt.wantToken) {
+				t.Errorf("expected log output to contain %q, got: %s", tt.wantToken, out)
+			}
+			if tt.token != "" && strings.Contains(out, tt.token) {
+				t.Errorf("token leaked into log output: %s", out)
 			}
 		})
 	}
@@ -196,6 +284,66 @@ func TestHFResolver_CacheHit(t *testing.T) {
 	}
 }
 
+// TestHFResolver_NoContentLengthForcesRedownload verifies that when the HEAD
+// response omits Content-Length, the resolver re-downloads the file rather
+// than trusting whatever bytes happen to be on disk. This closes the pre-
+// seeded cache attack: an attacker who plants a file named like a real
+// artifact in the cache must NOT be able to bypass verification just because
+// the upstream server doesn't advertise sizes.
+func TestHFResolver_NoContentLengthForcesRedownload(t *testing.T) {
+	getCount := int32(0)
+	body := []byte(`{"key":"fresh"}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/models/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"siblings": []map[string]string{{"rfilename": "config.json"}},
+			})
+			return
+		}
+		if r.Method == http.MethodHead {
+			// Deliberately NO Content-Length set.
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		atomic.AddInt32(&getCount, 1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	// Pre-seed the cache with garbage bytes the attacker controls.
+	preseedDir := filepath.Join(cacheDir, "org", "model", "main")
+	if err := os.MkdirAll(preseedDir, 0o755); err != nil {
+		t.Fatalf("preseed mkdir: %v", err)
+	}
+	preseedPath := filepath.Join(preseedDir, "config.json")
+	preseed := []byte("attacker-controlled-garbage")
+	if err := os.WriteFile(preseedPath, preseed, 0o644); err != nil {
+		t.Fatalf("preseed write: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewResolverWithOptions(logger, WithHFBaseURL(srv.URL), WithHFCacheDir(cacheDir))
+
+	pkg, err := r.Resolve("hf:org/model")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(pkg.Path, "config.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) == string(preseed) {
+		t.Errorf("cache was not invalidated — pre-seeded bytes still on disk")
+	}
+	if string(got) != string(body) {
+		t.Errorf("unexpected file contents: %q", got)
+	}
+	if atomic.LoadInt32(&getCount) == 0 {
+		t.Errorf("expected at least one GET request (re-download), got 0")
+	}
+}
+
 // ── error paths ────────────────────────────────────────────────────────────
 
 func TestHFResolver_Unauthorized(t *testing.T) {
@@ -262,5 +410,51 @@ func TestHFResolver_RetryOn5xx(t *testing.T) {
 	}
 	if calls < 2 {
 		t.Errorf("expected at least 2 manifest calls, got %d", calls)
+	}
+}
+
+// TestHFResolver_RetryAfterHonored verifies that a 429 with Retry-After is
+// honoured — the resolver waits the indicated number of seconds before the
+// next attempt.
+func TestHFResolver_RetryAfterHonored(t *testing.T) {
+	manifestCalls := int32(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/models/") {
+			n := atomic.AddInt32(&manifestCalls, 1)
+			if n == 1 {
+				// First attempt: rate-limit, ask for a 1-second wait.
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"siblings": []map[string]string{{"rfilename": "config.json"}},
+			})
+			return
+		}
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", "1")
+			return
+		}
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewResolverWithOptions(logger,
+		WithHFBaseURL(srv.URL),
+		WithHFCacheDir(t.TempDir()),
+	)
+
+	start := time.Now()
+	if _, err := r.Resolve("hf:org/model"); err != nil {
+		t.Fatalf("expected success after 429+Retry-After, got: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 1*time.Second {
+		t.Errorf("expected to wait at least 1s for Retry-After, waited %v", elapsed)
+	}
+	if got := atomic.LoadInt32(&manifestCalls); got < 2 {
+		t.Errorf("expected at least 2 manifest calls, got %d", got)
 	}
 }

--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -12,6 +12,7 @@ import (
 
 type resolver struct {
 	logger *slog.Logger
+	hf     HFConfig
 }
 
 func NewResolver(logger *slog.Logger) Resolver {
@@ -35,10 +36,9 @@ func (r *resolver) Resolve(target string) (*ResolvedPackage, error) {
 	}
 }
 
-// resolveHuggingFace is a Day-1 stub. Pulling models from HuggingFace lands
-// in a later milestone of the v0.4 AIBOM module.
+// resolveHuggingFace dispatches to the v0.4 HF download + cache implementation.
 func (r *resolver) resolveHuggingFace(target string) (*ResolvedPackage, error) {
-	return nil, fmt.Errorf("hf: targets not yet implemented (target=%q)", target)
+	return r.resolveHuggingFaceImpl(target)
 }
 
 func (r *resolver) resolveLocal(path string) (*ResolvedPackage, error) {

--- a/providers/resolver_test.go
+++ b/providers/resolver_test.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -644,16 +643,8 @@ func TestResolve_LocalDirectory_PlainProjectDefaultsToMCPServer(t *testing.T) {
 	}
 }
 
-func TestResolve_HuggingFaceTarget_NotYetImplemented(t *testing.T) {
-	r := newResolver(t)
-	_, err := r.Resolve("hf:meta-llama/Llama-3-8B")
-	if err == nil {
-		t.Fatal("expected error for hf: target")
-	}
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Errorf("expected 'not yet implemented' error, got: %v", err)
-	}
-}
+// HF resolver integration tests live in hf_resolver_test.go and use
+// httptest.Server so we never touch the real HuggingFace API.
 
 // ── isModelArtifactFile ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Day 8 of v0.4 AIBOM. End-to-end `oxvault scan hf:org/model[@revision]`.

- hf: prefix parsing with @revision, default main
- HF API v1 manifest fetch + filename filtering to security-relevant files
- Cache to ~/.cache/oxvault/hf/{org}/{model}/{rev}/, HEAD size check for idempotency, atomic temp+rename writes
- Per-file (4 GiB) + total cache (16 GiB) size caps
- HTTP: 30s timeout, exp backoff on 5xx, Retry-After on 429, clear 401/404 errors
- CLI flags: --hf-token, --hf-revision, --hf-cache-dir, --hf-max-file-bytes, --hf-max-cache-bytes
- Tests use httptest.Server (no real HF calls): parseHFTarget table tests + 5 integration scenarios

Pre-merge: pending.