### PR TITLE
feat(aibom): Day 9 — engine wiring + CLI flags

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,68 @@
 # Scanner Development Log
 
+## Day 9 — Engine wiring + CLI flag surface — 2026-04-28
+
+Branch: `feat/aibom-day9-cli`
+
+### What shipped
+- **`engines/scanner.go`** — replaced the Day 1-8 placeholder error (`"AIBOM scanning lands in v0.4 — wire-up coming Day 9"`) with real dispatch. `KindModelArtifact` and `KindModelDirectory` packages now flow through `scanModelArtifact()` which calls `aibomComposer.Scan(target)`, applies skip-flag filtering, and runs the same suppression + report shape used by MCP scans. **`oxvault scan ./model.pkl`, `oxvault scan ./model-dir/`, and `oxvault scan hf:org/model` are all functional end-to-end.**
+- **`engines.NewScanner`** — added `aibomComposer providers.AIBOMComposer` parameter (positioned after `netProbe`, before `logger`). Nil composer is allowed for tests that exercise the MCP-only flow; production wiring through `app.NewApp` always supplies one.
+- **`engines.ScanOptions`** — added `SkipPickle`, `SkipONNX`, `SkipSafetensors`, `SkipModelCard`, `SkipSignature` bool fields. Filtering happens AFTER the composer returns by rule-prefix match (`aibom-pickle-*` etc.) — composer stays untouched, mirroring `SkipSAST` / `SkipManifest` semantics on the MCP side.
+- **`app/app.go`** — added six AIBOM provider fields and getters (`pickleAnalyzer`, `onnxValidator`, `safetensorsValidator`, `modelCardChecker`, `signatureVerifier`, `aibomComposer`). Functional options follow the suffix-`Provider` convention (`WithPickleAnalyzerProvider`, `WithONNXValidatorProvider`, `WithSafetensorsValidatorProvider`, `WithModelCardCheckerProvider`, `WithSignatureVerifierProvider`, `WithAIBOMComposer`) — the suffix avoids colliding with `providers.WithPickleAnalyzer` (the composer-level option) at call sites that import both packages. `InitProviders` lazy-creates each sub-provider then wires them into the default composer (skipping when an override has supplied either the composer OR individual sub-providers).
+- **`app.AppInterface`** — extended with `GetPickleAnalyzer`, `GetONNXValidator`, `GetSafetensorsValidator`, `GetModelCardChecker`, `GetSignatureVerifier`, `GetAIBOMComposer` so the existing compile-time guard catches any future drift.
+- **`config.Config`** — new `AIBOM` section with `MaxPickleBytes`, `TrustedIssuers []string`, `AdditionalTrustedIssuers []string`. Empty values flow through as no-ops, preserving backwards-compatible defaults.
+- **`providers/pickle.go`** — `NewPickleAnalyzer` now accepts variadic `PickleAnalyzerOption` and `WithPickleMaxFileBytes(int64)` overrides the outer-file size cap. Values exceeding the 2 GiB hard ceiling are clamped down to keep DoS guarantees intact. `analyzePickleFile` signature picked up an explicit `maxBytes int64` parameter; non-positive values fall back to the package-level `maxFileBytes` constant. Internal-only callers (`AnalyzeFile`, `AnalyzeDirectory`) thread the configured cap through.
+- **`cmd/main.go`** — eight new flags on `scanCmd`:
+  - `--skip-pickle`, `--skip-onnx`, `--skip-safetensors`, `--skip-modelcard`, `--skip-signature` — bool gates that drop findings produced by the matching sub-provider after the composer returns.
+  - `--max-pickle-size <bytes>` — overrides the pickle disassembler's outer-file size cap.
+  - `--trusted-issuers <csv>` — REPLACES the default OIDC issuer allowlist used by `SignatureVerifier`. Wraps `providers.WithTrustedIssuers`.
+  - `--additional-trusted-issuers <csv>` — MERGES the supplied issuers into the default list. Wraps `providers.WithAdditionalTrustedIssuers`.
+  - New `splitAndTrimCSV` helper trims whitespace and drops empty entries so users can paste a list directly.
+
+### Tests
+- **`engines/scanner_test.go`** — replaced the obsolete `TestScanner_Scan_RejectsModelArtifactKind` with five new test groups:
+  - `TestScanner_Scan_ModelArtifactKind_DispatchesToComposer` — verifies single-file (Args[0] used as target), directory (Path used), and Args-empty fallback paths.
+  - `TestScanner_Scan_ModelArtifact_NoMCPSidePipeline` — pins that SAST, dep-audit, hook-analyzer, and MCPClient.Connect are NEVER called for model targets.
+  - `TestScanner_Scan_ModelArtifact_NoComposer_Errors` — verifies the nil-composer path returns a descriptive error instead of NPE.
+  - `TestScanner_Scan_ModelArtifact_SkipFlags` — table test (7 cases) covering each skip flag independently plus the "skip everything" case. Each case wires a `MockAIBOMComposer` returning all five rule families and asserts the expected subset survives filtering.
+  - `TestScanner_Scan_ModelDirectory_HFTarget` — simulates the HF resolver's output (Kind=KindModelDirectory + cache directory Path) and verifies dispatch works the same as a local directory scan.
+  - `TestScanner_Scan_ModelArtifact_SuppressionApplied` — pins that `.oxvaultignore` runs for AIBOM scans the same way it runs for MCP scans (regression guard on the suppression contract).
+- **`app/app_test.go`** — three new tests:
+  - `TestInitProviders_WiresAIBOMSubProviders` — Initialize wires every getter non-nil.
+  - `TestInitProviders_AIBOMOverridesNotReplaced` — functional options are not overwritten by InitProviders (lazy init contract).
+  - `TestInitProviders_DefaultComposerUsesWiredSubProviders` — the default composer path consumes the wired sub-providers (sub-providers must be created BEFORE the composer in InitProviders ordering).
+- All 8 existing scanner test helpers updated for the new `NewScanner` signature; `newTestScannerWithComposer` added so AIBOM-side tests don't need to wire the full mock surface manually.
+
+### Key design decisions
+- **Skip-flag filtering at the engine layer, not the composer:** the composer's contract stays "scan everything that's there"; the engine drops what the user asked to skip. This is identical to how `SkipSAST` and `SkipManifest` work for MCP scans, avoids re-constructing the composer per scan, and keeps `aibom_composer.go` untouched. Filtering is by rule-prefix (`aibom-pickle-*` etc.) so adding a new sub-provider only requires adding one prefix to `filterAIBOMFindings`.
+- **Single-file vs directory target selection:** the resolver places the absolute artifact filename in `pkg.Args[0]` for single-file targets and leaves `pkg.Path` pointing at the parent directory. The engine prefers `Args[0]` when present so the composer dispatches to ONE sub-provider rather than walking the parent directory (which would surface unrelated findings). Falls back to `Path` when `Args` is empty for robustness.
+- **Suppression dir for AIBOM scans uses pkg.Path (parent directory):** model authors can ship `.oxvaultignore` next to their weights without touching unrelated MCP server config. Same `Suppressor.LoadIgnoreFile + Filter` flow as MCP scans — no duplicate code path.
+- **Functional-option naming uses the `Provider` suffix to avoid package shadowing:** `WithPickleAnalyzer` already exists in `providers/aibom_composer.go` as a composer-level option. The app-container option is `WithPickleAnalyzerProvider` so callers (especially tests) that import both packages don't have to use ugly aliasing.
+- **`max-pickle-size` clamps down, never up:** values above the 2 GiB ceiling are silently clamped to the default. Allowing a wider cap would mean the disassembler would accept files larger than what the DoS guards are tested against — failure mode here is "scan stops early on huge file", which is the safer of the two.
+- **`--trusted-issuers` REPLACES, `--additional-trusted-issuers` MERGES:** matches the `providers.WithTrustedIssuers` / `WithAdditionalTrustedIssuers` semantics that landed in Day 7. `--trusted-issuers` is the "I know exactly which issuers I want" flag; `--additional-trusted-issuers` is the "extend the defaults" flag. The CLI help text calls out the difference explicitly so users picking the wrong one is recoverable.
+- **`AIBOMComposer` is optional in `NewScanner`:** wiring an AIBOM composer is mandatory for production (`app.InitEngines` always supplies one), but the parameter accepts nil for unit tests that only exercise the MCP-server flow. A nil composer hitting a model-artifact target returns a descriptive error rather than panicking — defence against accidental nil derefs in tests that build the engine directly.
+
+### Files
+- `engines/scanner.go` (Day 9 dispatch + ScanOptions extension + filterAIBOMFindings helper)
+- `engines/scanner_test.go` (six new test groups, table tests for skip flags)
+- `app/app.go` (six AIBOM fields, six functional options, six getters, AIBOM section in InitProviders, composer passed to NewScanner)
+- `app/app_test.go` (three new app wiring tests)
+- `config/config.go` (AIBOMOptions struct: MaxPickleBytes, TrustedIssuers, AdditionalTrustedIssuers)
+- `providers/pickle.go` (PickleAnalyzerOption + WithPickleMaxFileBytes; analyzePickleFile signature)
+- `cmd/main.go` (eight new scan flags: --skip-pickle, --skip-onnx, --skip-safetensors, --skip-modelcard, --skip-signature, --max-pickle-size, --trusted-issuers, --additional-trusted-issuers; splitAndTrimCSV helper)
+- `DEVLOG.md` (this entry)
+
+### Quality gates
+- `make build` — clean
+- `make test` — all packages pass (672 PASS subtests)
+- `make lint` — 0 issues
+- Manual end-to-end smoke:
+  - `oxvault scan ./testdata/aibom/pickle/malicious/os_system.pkl` — emits `aibom-pickle-os-system` CRITICAL plus suppression-deferred signature INFO
+  - `oxvault scan ./testdata/aibom/pickle/malicious/ --skip-pickle` — drops all `aibom-pickle-*` findings, surfaces `aibom-signature-missing` per artifact
+  - `oxvault scan ./testdata/aibom/pickle/malicious/ --skip-pickle --skip-signature` — only `aibom-modelcard-missing` survives
+
+---
+
 ## Day 8 — Hugging Face resolver — 2026-04-28
 
 Branch: `feat/aibom-day8-hf-resolver`

--- a/app/app.go
+++ b/app/app.go
@@ -31,6 +31,14 @@ type AppInterface interface {
 	GetNetProbe() providers.NetProbe
 	GetSuppressor() providers.Suppressor
 
+	// AIBOM providers (v0.4)
+	GetPickleAnalyzer() providers.PickleAnalyzer
+	GetONNXValidator() providers.ONNXValidator
+	GetSafetensorsValidator() providers.SafetensorsValidator
+	GetModelCardChecker() providers.ModelCardChecker
+	GetSignatureVerifier() providers.SignatureVerifier
+	GetAIBOMComposer() providers.AIBOMComposer
+
 	// Init steps
 	InitProviders() error
 	InitEngines() error
@@ -54,6 +62,16 @@ type App struct {
 	resolver     providers.Resolver
 	netProbe     providers.NetProbe
 	suppressor   providers.Suppressor
+
+	// AIBOM sub-providers (v0.4) and the composer that fans out to them.
+	// Wired in InitProviders. Each is overridable via WithXxx so tests can
+	// inject mocks without touching the rest of the container.
+	pickleAnalyzer       providers.PickleAnalyzer
+	onnxValidator        providers.ONNXValidator
+	safetensorsValidator providers.SafetensorsValidator
+	modelCardChecker     providers.ModelCardChecker
+	signatureVerifier    providers.SignatureVerifier
+	aibomComposer        providers.AIBOMComposer
 
 	// Engines
 	scanner engines.ScannerEngine
@@ -105,6 +123,46 @@ func WithSuppressor(s providers.Suppressor) AppOption {
 
 func WithLogger(l *slog.Logger) AppOption {
 	return func(a *App) { a.Logger = l }
+}
+
+// ── AIBOM functional options (v0.4) ────────────────────────────────────────
+
+// WithPickleAnalyzerProvider injects a PickleAnalyzer. Named with the
+// "Provider" suffix to avoid colliding with providers.WithPickleAnalyzer
+// (the composer-level option) — both are valid identifiers in their own
+// packages but `WithPickleAnalyzer` would shadow at call sites that import
+// both, e.g. tests in cmd/.
+func WithPickleAnalyzerProvider(p providers.PickleAnalyzer) AppOption {
+	return func(a *App) { a.pickleAnalyzer = p }
+}
+
+// WithONNXValidatorProvider injects an ONNXValidator.
+func WithONNXValidatorProvider(o providers.ONNXValidator) AppOption {
+	return func(a *App) { a.onnxValidator = o }
+}
+
+// WithSafetensorsValidatorProvider injects a SafetensorsValidator.
+func WithSafetensorsValidatorProvider(s providers.SafetensorsValidator) AppOption {
+	return func(a *App) { a.safetensorsValidator = s }
+}
+
+// WithModelCardCheckerProvider injects a ModelCardChecker.
+func WithModelCardCheckerProvider(m providers.ModelCardChecker) AppOption {
+	return func(a *App) { a.modelCardChecker = m }
+}
+
+// WithSignatureVerifierProvider injects a SignatureVerifier.
+func WithSignatureVerifierProvider(s providers.SignatureVerifier) AppOption {
+	return func(a *App) { a.signatureVerifier = s }
+}
+
+// WithAIBOMComposer injects an AIBOMComposer. When supplied, the sub-
+// provider options above are still honoured for direct getter access (for
+// example a test that wants to assert the composer was constructed with a
+// specific PickleAnalyzer mock can inject both), but InitProviders will not
+// re-wrap the sub-providers into a fresh composer.
+func WithAIBOMComposer(c providers.AIBOMComposer) AppOption {
+	return func(a *App) { a.aibomComposer = c }
 }
 
 // NewApp creates a new App with the given config and options
@@ -183,6 +241,50 @@ func (a *App) InitProviders() error {
 	if a.suppressor == nil {
 		a.suppressor = providers.NewSuppressor()
 	}
+
+	// ── AIBOM sub-providers (v0.4) ──────────────────────────────────────────
+	//
+	// Each sub-provider follows the same lazy-init pattern as the MCP
+	// providers above: only create a default when the caller has not
+	// supplied one via a functional option. This lets tests stub out an
+	// individual analyzer without rewiring the whole container.
+	if a.pickleAnalyzer == nil {
+		var pickleOpts []providers.PickleAnalyzerOption
+		if a.Config != nil && a.Config.AIBOM.MaxPickleBytes > 0 {
+			pickleOpts = append(pickleOpts, providers.WithPickleMaxFileBytes(a.Config.AIBOM.MaxPickleBytes))
+		}
+		a.pickleAnalyzer = providers.NewPickleAnalyzer(pickleOpts...)
+	}
+	if a.onnxValidator == nil {
+		a.onnxValidator = providers.NewONNXValidator()
+	}
+	if a.safetensorsValidator == nil {
+		a.safetensorsValidator = providers.NewSafetensorsValidator()
+	}
+	if a.modelCardChecker == nil {
+		a.modelCardChecker = providers.NewModelCardChecker()
+	}
+	if a.signatureVerifier == nil {
+		var sigOpts []providers.SignatureVerifierOption
+		if a.Config != nil {
+			if len(a.Config.AIBOM.TrustedIssuers) > 0 {
+				sigOpts = append(sigOpts, providers.WithTrustedIssuers(a.Config.AIBOM.TrustedIssuers))
+			}
+			if len(a.Config.AIBOM.AdditionalTrustedIssuers) > 0 {
+				sigOpts = append(sigOpts, providers.WithAdditionalTrustedIssuers(a.Config.AIBOM.AdditionalTrustedIssuers))
+			}
+		}
+		a.signatureVerifier = providers.NewSignatureVerifier(sigOpts...)
+	}
+	if a.aibomComposer == nil {
+		a.aibomComposer = providers.NewComposer(
+			providers.WithPickleAnalyzer(a.pickleAnalyzer),
+			providers.WithONNXValidator(a.onnxValidator),
+			providers.WithSafetensorsValidator(a.safetensorsValidator),
+			providers.WithModelCardChecker(a.modelCardChecker),
+			providers.WithSignatureVerifier(a.signatureVerifier),
+		)
+	}
 	return nil
 }
 
@@ -199,6 +301,7 @@ func (a *App) InitEngines() error {
 			a.reporter,
 			a.suppressor,
 			a.netProbe,
+			a.aibomComposer,
 			a.Logger,
 		)
 	}
@@ -231,3 +334,16 @@ func (a *App) GetPinStore() providers.PinStore         { return a.pinStore }
 func (a *App) GetResolver() providers.Resolver         { return a.resolver }
 func (a *App) GetNetProbe() providers.NetProbe         { return a.netProbe }
 func (a *App) GetSuppressor() providers.Suppressor     { return a.suppressor }
+
+// AIBOM getters (v0.4) — each returns the wired sub-provider so tests and
+// integrations can assert / interact with them without reaching into App
+// fields directly.
+
+func (a *App) GetPickleAnalyzer() providers.PickleAnalyzer { return a.pickleAnalyzer }
+func (a *App) GetONNXValidator() providers.ONNXValidator   { return a.onnxValidator }
+func (a *App) GetSafetensorsValidator() providers.SafetensorsValidator {
+	return a.safetensorsValidator
+}
+func (a *App) GetModelCardChecker() providers.ModelCardChecker   { return a.modelCardChecker }
+func (a *App) GetSignatureVerifier() providers.SignatureVerifier { return a.signatureVerifier }
+func (a *App) GetAIBOMComposer() providers.AIBOMComposer         { return a.aibomComposer }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -305,3 +305,109 @@ func TestShutdown_BeforeInitialize(t *testing.T) {
 func TestAppInterface_ComplianceGuard(t *testing.T) {
 	var _ AppInterface = (*App)(nil)
 }
+
+// ── AIBOM wiring tests (Day 9) ───────────────────────────────────────────────
+
+// TestInitProviders_WiresAIBOMSubProviders verifies InitProviders constructs
+// every AIBOM sub-provider plus the top-level composer when no overrides
+// are passed. After init, every getter must return a non-nil instance so
+// the engine can hand off model-artifact targets to the composer.
+func TestInitProviders_WiresAIBOMSubProviders(t *testing.T) {
+	a := NewApp(defaultTestConfig())
+
+	if err := a.Initialize(); err != nil {
+		t.Fatalf("Initialize() error: %v", err)
+	}
+
+	if a.GetPickleAnalyzer() == nil {
+		t.Error("expected pickleAnalyzer to be wired")
+	}
+	if a.GetONNXValidator() == nil {
+		t.Error("expected onnxValidator to be wired")
+	}
+	if a.GetSafetensorsValidator() == nil {
+		t.Error("expected safetensorsValidator to be wired")
+	}
+	if a.GetModelCardChecker() == nil {
+		t.Error("expected modelCardChecker to be wired")
+	}
+	if a.GetSignatureVerifier() == nil {
+		t.Error("expected signatureVerifier to be wired")
+	}
+	if a.GetAIBOMComposer() == nil {
+		t.Error("expected aibomComposer to be wired")
+	}
+}
+
+// TestInitProviders_AIBOMOverridesNotReplaced verifies that AIBOM functional
+// options pre-populate fields and are NOT overwritten by InitProviders. Same
+// lazy-init contract as the MCP providers.
+func TestInitProviders_AIBOMOverridesNotReplaced(t *testing.T) {
+	pickle := &testutil.MockPickleAnalyzer{}
+	onnx := &testutil.MockONNXValidator{}
+	safetensors := &testutil.MockSafetensorsValidator{}
+	modelCard := &testutil.MockModelCardChecker{}
+	signature := &testutil.MockSignatureVerifier{}
+	composer := &testutil.MockAIBOMComposer{}
+
+	a := NewApp(defaultTestConfig(),
+		WithPickleAnalyzerProvider(pickle),
+		WithONNXValidatorProvider(onnx),
+		WithSafetensorsValidatorProvider(safetensors),
+		WithModelCardCheckerProvider(modelCard),
+		WithSignatureVerifierProvider(signature),
+		WithAIBOMComposer(composer),
+	)
+
+	if err := a.Initialize(); err != nil {
+		t.Fatalf("Initialize() error: %v", err)
+	}
+
+	if a.GetPickleAnalyzer() != pickle {
+		t.Error("pickleAnalyzer mock was overwritten by InitProviders")
+	}
+	if a.GetONNXValidator() != onnx {
+		t.Error("onnxValidator mock was overwritten by InitProviders")
+	}
+	if a.GetSafetensorsValidator() != safetensors {
+		t.Error("safetensorsValidator mock was overwritten by InitProviders")
+	}
+	if a.GetModelCardChecker() != modelCard {
+		t.Error("modelCardChecker mock was overwritten by InitProviders")
+	}
+	if a.GetSignatureVerifier() != signature {
+		t.Error("signatureVerifier mock was overwritten by InitProviders")
+	}
+	if a.GetAIBOMComposer() != composer {
+		t.Error("aibomComposer mock was overwritten by InitProviders")
+	}
+}
+
+// TestInitProviders_DefaultComposerUsesWiredSubProviders verifies that the
+// default composer path (no WithAIBOMComposer override) is constructed with
+// the wired sub-providers. Tests this indirectly by asserting the composer
+// is non-nil and that the sub-providers it consumed are also non-nil — the
+// composer's NewComposer constructor would have replaced any nil supplied
+// option with its own default, so finding non-nil values everywhere is
+// sufficient evidence of correct wiring.
+func TestInitProviders_DefaultComposerUsesWiredSubProviders(t *testing.T) {
+	a := NewApp(defaultTestConfig())
+
+	if err := a.InitProviders(); err != nil {
+		t.Fatalf("InitProviders() error: %v", err)
+	}
+
+	if a.GetAIBOMComposer() == nil {
+		t.Fatal("expected default composer to be constructed")
+	}
+	// Sub-providers must be wired BEFORE the composer is built so the
+	// composer can consume them. If any sub-provider is nil here, the
+	// composer would have silently fallen back to its own default and
+	// overrides would be useless.
+	if a.GetPickleAnalyzer() == nil {
+		t.Error("pickleAnalyzer must be wired before composer construction")
+	}
+	if a.GetSignatureVerifier() == nil {
+		t.Error("signatureVerifier must be wired before composer construction")
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -136,7 +136,7 @@ func newScanCmd() *cobra.Command {
 		// AIBOM tuning (v0.4)
 		maxPickleBytes            int64
 		trustedIssuersCSV         string
-		additionalTrustedIssusCSV string
+		additionalTrustedIssuersCSV string
 	)
 
 	cmd := &cobra.Command{
@@ -193,7 +193,7 @@ Config-based scanning:
 			if issuers := splitAndTrimCSV(trustedIssuersCSV); len(issuers) > 0 {
 				cfg.AIBOM.TrustedIssuers = issuers
 			}
-			if issuers := splitAndTrimCSV(additionalTrustedIssusCSV); len(issuers) > 0 {
+			if issuers := splitAndTrimCSV(additionalTrustedIssuersCSV); len(issuers) > 0 {
 				cfg.AIBOM.AdditionalTrustedIssuers = issuers
 			}
 
@@ -264,7 +264,7 @@ Config-based scanning:
 	// AIBOM tuning (v0.4)
 	cmd.Flags().Int64Var(&maxPickleBytes, "max-pickle-size", 0, "Max bytes for pickle disassembly (default: 2 GiB; values above the default are clamped)")
 	cmd.Flags().StringVar(&trustedIssuersCSV, "trusted-issuers", "", "Comma-separated OIDC issuer URLs that REPLACE the default trusted-issuer list for signature verification")
-	cmd.Flags().StringVar(&additionalTrustedIssusCSV, "additional-trusted-issuers", "", "Comma-separated OIDC issuer URLs that MERGE into the default trusted-issuer list")
+	cmd.Flags().StringVar(&additionalTrustedIssuersCSV, "additional-trusted-issuers", "", "Comma-separated OIDC issuer URLs that MERGE into the default trusted-issuer list")
 
 	return cmd
 }
@@ -283,6 +283,9 @@ func splitAndTrimCSV(s string) []string {
 		if t := strings.TrimSpace(p); t != "" {
 			out = append(out, t)
 		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,6 +125,18 @@ func newScanCmd() *cobra.Command {
 		hfCacheDir      string
 		hfMaxFileBytes  int64
 		hfMaxCacheBytes int64
+
+		// AIBOM sub-provider toggles (v0.4)
+		skipPickle      bool
+		skipONNX        bool
+		skipSafetensors bool
+		skipModelCard   bool
+		skipSignature   bool
+
+		// AIBOM tuning (v0.4)
+		maxPickleBytes            int64
+		trustedIssuersCSV         string
+		additionalTrustedIssusCSV string
 	)
 
 	cmd := &cobra.Command{
@@ -174,6 +186,17 @@ Config-based scanning:
 				cfg.HF.MaxCacheBytes = hfMaxCacheBytes
 			}
 
+			// AIBOM tuning (v0.4)
+			if maxPickleBytes > 0 {
+				cfg.AIBOM.MaxPickleBytes = maxPickleBytes
+			}
+			if issuers := splitAndTrimCSV(trustedIssuersCSV); len(issuers) > 0 {
+				cfg.AIBOM.TrustedIssuers = issuers
+			}
+			if issuers := splitAndTrimCSV(additionalTrustedIssusCSV); len(issuers) > 0 {
+				cfg.AIBOM.AdditionalTrustedIssuers = issuers
+			}
+
 			// Apply no-color globally before any output
 			if noColor || cfg.OutputFormat != providers.FormatTerminal {
 				color.NoColor = true
@@ -185,11 +208,16 @@ Config-based scanning:
 			}
 
 			scanOpts := engines.ScanOptions{
-				SkipSAST:     cfg.SkipSAST,
-				SkipManifest: cfg.SkipManifest,
-				SkipEgress:   cfg.SkipEgress,
-				ProbeNetwork: cfg.ProbeNetwork,
-				FailOn:       cfg.FailOn,
+				SkipSAST:        cfg.SkipSAST,
+				SkipManifest:    cfg.SkipManifest,
+				SkipEgress:      cfg.SkipEgress,
+				ProbeNetwork:    cfg.ProbeNetwork,
+				FailOn:          cfg.FailOn,
+				SkipPickle:      skipPickle,
+				SkipONNX:        skipONNX,
+				SkipSafetensors: skipSafetensors,
+				SkipModelCard:   skipModelCard,
+				SkipSignature:   skipSignature,
 			}
 
 			minConf := parseMinConfidence(minConfidence)
@@ -223,7 +251,40 @@ Config-based scanning:
 	cmd.Flags().Int64Var(&hfMaxFileBytes, "hf-max-file-bytes", 0, "Max bytes per HF file (default: 4 GiB)")
 	cmd.Flags().Int64Var(&hfMaxCacheBytes, "hf-max-cache-bytes", 0, "Max total HF cache bytes (default: 16 GiB)")
 
+	// AIBOM sub-provider toggles (v0.4) — each flag drops findings produced
+	// by the matching sub-provider after the composer returns. The composer
+	// itself stays untouched, mirroring how SkipSAST / SkipManifest gate
+	// MCP-side analyzers.
+	cmd.Flags().BoolVar(&skipPickle, "skip-pickle", false, "Skip pickle disassembler findings (aibom-pickle-*)")
+	cmd.Flags().BoolVar(&skipONNX, "skip-onnx", false, "Skip ONNX validator findings (aibom-onnx-*)")
+	cmd.Flags().BoolVar(&skipSafetensors, "skip-safetensors", false, "Skip safetensors validator findings (aibom-safetensors-*)")
+	cmd.Flags().BoolVar(&skipModelCard, "skip-modelcard", false, "Skip model card checker findings (aibom-modelcard-*)")
+	cmd.Flags().BoolVar(&skipSignature, "skip-signature", false, "Skip signature verifier findings (aibom-signature-*)")
+
+	// AIBOM tuning (v0.4)
+	cmd.Flags().Int64Var(&maxPickleBytes, "max-pickle-size", 0, "Max bytes for pickle disassembly (default: 2 GiB; values above the default are clamped)")
+	cmd.Flags().StringVar(&trustedIssuersCSV, "trusted-issuers", "", "Comma-separated OIDC issuer URLs that REPLACE the default trusted-issuer list for signature verification")
+	cmd.Flags().StringVar(&additionalTrustedIssusCSV, "additional-trusted-issuers", "", "Comma-separated OIDC issuer URLs that MERGE into the default trusted-issuer list")
+
 	return cmd
+}
+
+// splitAndTrimCSV splits a comma-separated string and trims whitespace from
+// each element. Empty entries are dropped. Used by --trusted-issuers and
+// --additional-trusted-issuers so users can paste a list directly without
+// worrying about stray spaces.
+func splitAndTrimCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // runSingleScan handles the traditional `oxvault scan <target>` path.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitAndTrimCSV(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "whitespace only", in: "   ", want: nil},
+		{name: "single", in: "https://accounts.google.com", want: []string{"https://accounts.google.com"}},
+		{name: "multi", in: "a,b,c", want: []string{"a", "b", "c"}},
+		{name: "trim each", in: " a , b , c ", want: []string{"a", "b", "c"}},
+		{name: "leading comma", in: ",https://oidc.example", want: []string{"https://oidc.example"}},
+		{name: "trailing comma", in: "https://oidc.example,", want: []string{"https://oidc.example"}},
+		{name: "double comma", in: "a,,b", want: []string{"a", "b"}},
+		{name: "all empty entries", in: " , ,  ,", want: nil},
+		{name: "real-world issuers", in: "https://accounts.google.com, https://token.actions.githubusercontent.com", want: []string{"https://accounts.google.com", "https://token.actions.githubusercontent.com"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitAndTrimCSV(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitAndTrimCSV(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,29 @@ type Config struct {
 
 	// Hugging Face resolver (v0.4 AIBOM)
 	HF HFOptions
+
+	// AIBOM scan options (v0.4)
+	AIBOM AIBOMOptions
+}
+
+// AIBOMOptions configure the AIBOM module (model artifact scanning). All
+// fields are optional — providers install sensible defaults when these are
+// left zero / empty.
+type AIBOMOptions struct {
+	// MaxPickleBytes overrides the outer-file size cap on pickle disassembly.
+	// Zero leaves the provider default in place (2 GiB). Values exceeding
+	// the provider's hard ceiling are clamped down inside the provider.
+	MaxPickleBytes int64
+
+	// TrustedIssuers REPLACES the default OIDC issuer allowlist used by
+	// SignatureVerifier. Empty leaves the defaults in place.
+	TrustedIssuers []string
+
+	// AdditionalTrustedIssuers MERGES the supplied issuers into the default
+	// OIDC issuer allowlist. Use this when you want to extend (not replace)
+	// the bundled defaults — e.g. accept the standard Sigstore public
+	// issuers AND your internal corporate OIDC.
+	AdditionalTrustedIssuers []string
 }
 
 // HFOptions configure the Hugging Face resolver. All fields are optional —

--- a/engines/scanner.go
+++ b/engines/scanner.go
@@ -16,6 +16,18 @@ type ScanOptions struct {
 	SkipEgress   bool   // Skip network egress detection
 	ProbeNetwork bool   // Run runtime network probe after static scan
 	FailOn       string // Exit non-zero at this severity: critical, high, warning
+
+	// AIBOM sub-provider toggles. When set, findings produced by the
+	// matching sub-provider are dropped after the composer returns. The
+	// composer itself remains untouched — keeping skip behaviour purely
+	// at the engine layer mirrors how SkipSAST / SkipManifest are
+	// implemented for MCP scans and avoids re-wiring the composer per
+	// scan. See filterAIBOMFindings for the exact rule-prefix mapping.
+	SkipPickle      bool // Drop aibom-pickle-* findings
+	SkipONNX        bool // Drop aibom-onnx-* findings
+	SkipSafetensors bool // Drop aibom-safetensors-* findings
+	SkipModelCard   bool // Drop aibom-modelcard-* findings
+	SkipSignature   bool // Drop aibom-signature-* findings
 }
 
 // ScanReport holds the results of a scan
@@ -57,18 +69,26 @@ type ScannerEngine interface {
 }
 
 type scanner struct {
-	resolver     providers.Resolver
-	mcpClient    providers.MCPClient
-	ruleMatcher  providers.RuleMatcher
-	sastAnalyzer providers.SASTAnalyzer
-	depAuditor   providers.DepAuditor
-	hookAnalyzer providers.HookAnalyzer
-	reporter     providers.Reporter
-	suppressor   providers.Suppressor
-	netProbe     providers.NetProbe // optional — nil if not wired
-	logger       *slog.Logger
+	resolver      providers.Resolver
+	mcpClient     providers.MCPClient
+	ruleMatcher   providers.RuleMatcher
+	sastAnalyzer  providers.SASTAnalyzer
+	depAuditor    providers.DepAuditor
+	hookAnalyzer  providers.HookAnalyzer
+	reporter      providers.Reporter
+	suppressor    providers.Suppressor
+	netProbe      providers.NetProbe      // optional — nil if not wired
+	aibomComposer providers.AIBOMComposer // optional — nil falls back to MCP-only behaviour
+	logger        *slog.Logger
 }
 
+// NewScanner constructs the production ScannerEngine.
+//
+// The AIBOMComposer is optional: callers that build the engine without one
+// can still scan MCP servers, but model-artifact / model-directory targets
+// will surface a "no composer wired" error instead of a panic. App
+// container always wires the composer in InitEngines, so the nil branch
+// is reserved for unit tests that exercise the MCP-only flow.
 func NewScanner(
 	resolver providers.Resolver,
 	mcpClient providers.MCPClient,
@@ -79,19 +99,21 @@ func NewScanner(
 	reporter providers.Reporter,
 	suppressor providers.Suppressor,
 	netProbe providers.NetProbe,
+	aibomComposer providers.AIBOMComposer,
 	logger *slog.Logger,
 ) ScannerEngine {
 	return &scanner{
-		resolver:     resolver,
-		mcpClient:    mcpClient,
-		ruleMatcher:  ruleMatcher,
-		sastAnalyzer: sastAnalyzer,
-		depAuditor:   depAuditor,
-		hookAnalyzer: hookAnalyzer,
-		reporter:     reporter,
-		suppressor:   suppressor,
-		netProbe:     netProbe,
-		logger:       logger,
+		resolver:      resolver,
+		mcpClient:     mcpClient,
+		ruleMatcher:   ruleMatcher,
+		sastAnalyzer:  sastAnalyzer,
+		depAuditor:    depAuditor,
+		hookAnalyzer:  hookAnalyzer,
+		reporter:      reporter,
+		suppressor:    suppressor,
+		netProbe:      netProbe,
+		aibomComposer: aibomComposer,
+		logger:        logger,
 	}
 }
 
@@ -106,16 +128,14 @@ func (s *scanner) Scan(target string, opts ScanOptions) (*ScanReport, error) {
 	}
 	report.Package = pkg
 
-	// AIBOM dispatch is wired in Day 9 of the v0.4 milestone. The resolver
-	// already classifies model artifacts and directories, so we reject them
-	// here with a clear message rather than running MCP-server scanning over
-	// model weights (which would produce nonsense findings).
+	// AIBOM dispatch — model artifacts and model directories run through
+	// the AIBOMComposer instead of the MCP-server pipeline. MCP-server
+	// scanning over model weights would produce nonsense findings (every
+	// pickle byte sequence looks like a "command injection" to the SAST
+	// patterns), so we never fall through to the MCP path for these kinds.
 	switch pkg.Kind {
 	case providers.KindModelArtifact, providers.KindModelDirectory:
-		return nil, fmt.Errorf(
-			"AIBOM scanning of %s lands in v0.4 — wire-up coming Day 9 (path=%q)",
-			pkg.Kind, pkg.Path,
-		)
+		return s.scanModelArtifact(report, pkg, opts)
 	}
 
 	// Step 2: Static analysis on source code
@@ -247,6 +267,119 @@ func (s *scanner) Scan(target string, opts ScanOptions) (*ScanReport, error) {
 
 	s.logger.Info("scan complete", "findings", len(report.Findings))
 	return report, nil
+}
+
+// scanModelArtifact runs the AIBOM composer over a model artifact / model
+// directory target and applies the same suppression + report shape used by
+// MCP-server scans. Day 9 of the v0.4 AIBOM milestone — replaces the
+// pre-wire stub that returned a "wire-up coming" error.
+//
+// Path selection mirrors the resolver's contract:
+//
+//   - For KindModelArtifact, the resolver places the parent directory in
+//     pkg.Path and the absolute artifact filename in pkg.Args[0]. We hand
+//     the artifact path to the composer so it dispatches to a single
+//     sub-provider (no walk).
+//   - For KindModelDirectory, the resolver leaves pkg.Path pointing at the
+//     directory itself. The composer walks it, dispatches every recognised
+//     file, and runs cross-file aggregation (missing-card, signature
+//     verification per artifact).
+//
+// Skip-flag enforcement happens AFTER the composer returns: filterAIBOMFindings
+// drops findings whose Rule prefix matches a skipped sub-provider. That keeps
+// the composer untouched and matches how SkipSAST / SkipManifest are
+// implemented for MCP scans.
+//
+// The named return is load-bearing only insofar as suppression mutates
+// report.Findings via append — the function does not panic-recover, since
+// every sub-provider already wraps its own panics (Day 5 onnx, Day 6
+// modelcard, Day 7 signature).
+func (s *scanner) scanModelArtifact(report *ScanReport, pkg *providers.ResolvedPackage, opts ScanOptions) (*ScanReport, error) {
+	if s.aibomComposer == nil {
+		return nil, fmt.Errorf(
+			"no AIBOMComposer wired — cannot scan %s target %q (build the engine via app.NewApp so InitEngines wires the composer)",
+			pkg.Kind, pkg.Path,
+		)
+	}
+
+	target := pkg.Path
+	if pkg.Kind == providers.KindModelArtifact && len(pkg.Args) > 0 && pkg.Args[0] != "" {
+		// The resolver re-attaches the absolute artifact path to Args[0]
+		// for single-file targets. Prefer that over pkg.Path (which points
+		// at the parent directory) so the composer dispatches to one
+		// sub-provider rather than walking the whole directory.
+		target = pkg.Args[0]
+	}
+
+	s.logger.Info("running AIBOM composer", "target", target, "kind", pkg.Kind)
+	findings := s.aibomComposer.Scan(target)
+	s.logger.Info("AIBOM composer complete", "findings", len(findings))
+
+	findings = filterAIBOMFindings(findings, opts)
+	report.Findings = append(report.Findings, findings...)
+
+	// Apply suppression — same path as the MCP flow. The .oxvaultignore
+	// file is read from the artifact's directory so model authors can ship
+	// scoped suppressions next to their weights without touching their
+	// MCP server config.
+	if s.suppressor != nil && report.Package != nil {
+		ignoreDir := report.Package.Path
+		if err := s.suppressor.LoadIgnoreFile(ignoreDir); err != nil {
+			s.logger.Warn("could not load .oxvaultignore", "error", err)
+		}
+		kept, suppressed := s.suppressor.Filter(report.Findings)
+		report.Findings = kept
+		report.Suppressed = suppressed
+		s.logger.Info("suppression applied",
+			"kept", len(kept),
+			"suppressed", len(suppressed),
+		)
+	}
+
+	s.logger.Info("scan complete", "findings", len(report.Findings))
+	return report, nil
+}
+
+// filterAIBOMFindings drops findings produced by sub-providers the user
+// asked to skip. The mapping is by rule-id prefix:
+//
+//	aibom-pickle-*       → SkipPickle
+//	aibom-onnx-*         → SkipONNX
+//	aibom-safetensors-*  → SkipSafetensors
+//	aibom-modelcard-*    → SkipModelCard
+//	aibom-signature-*    → SkipSignature
+//
+// Findings that do not match any AIBOM prefix (e.g. aibom-clean,
+// aibom-unknown-format) are always preserved — skip flags only gate the
+// per-sub-provider rule families.
+func filterAIBOMFindings(findings []providers.Finding, opts ScanOptions) []providers.Finding {
+	if !opts.SkipPickle && !opts.SkipONNX && !opts.SkipSafetensors && !opts.SkipModelCard && !opts.SkipSignature {
+		return findings
+	}
+	out := make([]providers.Finding, 0, len(findings))
+	for _, f := range findings {
+		switch {
+		case opts.SkipPickle && hasPrefix(f.Rule, "aibom-pickle-"):
+			continue
+		case opts.SkipONNX && hasPrefix(f.Rule, "aibom-onnx-"):
+			continue
+		case opts.SkipSafetensors && hasPrefix(f.Rule, "aibom-safetensors-"):
+			continue
+		case opts.SkipModelCard && hasPrefix(f.Rule, "aibom-modelcard-"):
+			continue
+		case opts.SkipSignature && hasPrefix(f.Rule, "aibom-signature-"):
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// hasPrefix is a tiny inlinable helper used by filterAIBOMFindings. We
+// intentionally avoid importing strings just for one HasPrefix call — keep
+// the engine package's import surface as narrow as possible.
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
 // extractSchemaDescriptions walks a JSON Schema and extracts all description fields

--- a/engines/scanner_test.go
+++ b/engines/scanner_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 // newTestScanner wires up a scanner with the given mocks and a discard logger.
+//
+// AIBOM composer is left nil — these tests exercise the MCP-server flow,
+// which never reaches the composer dispatch. Tests that need an AIBOM
+// composer use newTestScannerWithComposer below.
 func newTestScanner(
 	resolver *testutil.MockResolver,
 	mcpClient *testutil.MockMCPClient,
@@ -23,7 +27,28 @@ func newTestScanner(
 	depAuditor := &testutil.MockDepAuditor{}
 	hookAnalyzer := &testutil.MockHookAnalyzer{}
 	suppressor := &testutil.MockSuppressor{}
-	return NewScanner(resolver, mcpClient, ruleMatcher, sast, depAuditor, hookAnalyzer, reporter, suppressor, nil, logger)
+	return NewScanner(resolver, mcpClient, ruleMatcher, sast, depAuditor, hookAnalyzer, reporter, suppressor, nil, nil, logger)
+}
+
+// newTestScannerWithComposer wires up a scanner with an AIBOMComposer mock
+// for Day 9 model-artifact dispatch tests. All other dependencies follow the
+// same defaults as newTestScanner.
+func newTestScannerWithComposer(
+	resolver *testutil.MockResolver,
+	composer *testutil.MockAIBOMComposer,
+	suppressor *testutil.MockSuppressor,
+) ScannerEngine {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mcpClient := &testutil.MockMCPClient{}
+	ruleMatcher := &testutil.MockRuleMatcher{}
+	sast := &testutil.MockSASTAnalyzer{}
+	depAuditor := &testutil.MockDepAuditor{}
+	hookAnalyzer := &testutil.MockHookAnalyzer{}
+	reporter := &testutil.MockReporter{}
+	if suppressor == nil {
+		suppressor = &testutil.MockSuppressor{}
+	}
+	return NewScanner(resolver, mcpClient, ruleMatcher, sast, depAuditor, hookAnalyzer, reporter, suppressor, nil, composer, logger)
 }
 
 // defaultResolvedPackage returns a minimal ResolvedPackage used across tests.
@@ -65,44 +90,338 @@ func TestScanner_Scan_ResolveError(t *testing.T) {
 	}
 }
 
-// TestScanner_Scan_RejectsModelArtifactKind verifies that resolved packages
-// with PackageKind=KindModelArtifact / KindModelDirectory are rejected with
-// a clear "AIBOM scanning lands in v0.4 — wire-up coming Day 9" message.
-// MCP-server scanning over model weights would produce nonsense findings, so
-// the branch returns early before any sub-provider runs.
-func TestScanner_Scan_RejectsModelArtifactKind(t *testing.T) {
+// TestScanner_Scan_ModelArtifactKind_DispatchesToComposer verifies the Day 9
+// wiring: when the resolver classifies a target as KindModelArtifact or
+// KindModelDirectory, the scanner forwards it to the AIBOMComposer instead
+// of the MCP-server pipeline. The composer's findings flow through the
+// same suppression + report shape used by MCP scans.
+func TestScanner_Scan_ModelArtifactKind_DispatchesToComposer(t *testing.T) {
 	tests := []struct {
-		name string
-		kind providers.PackageKind
+		name        string
+		kind        providers.PackageKind
+		pkgPath     string
+		pkgArgs     []string
+		wantTarget  string
+		description string
 	}{
-		{"model artifact", providers.KindModelArtifact},
-		{"model directory", providers.KindModelDirectory},
+		{
+			name:        "single model artifact uses Args[0] as target",
+			kind:        providers.KindModelArtifact,
+			pkgPath:     "/tmp/models",
+			pkgArgs:     []string{"/tmp/models/weights.pkl"},
+			wantTarget:  "/tmp/models/weights.pkl",
+			description: "resolver places parent dir in Path and absolute file path in Args[0]",
+		},
+		{
+			name:        "model directory uses Path as target",
+			kind:        providers.KindModelDirectory,
+			pkgPath:     "/tmp/hf-cache/Llama",
+			pkgArgs:     nil,
+			wantTarget:  "/tmp/hf-cache/Llama",
+			description: "resolver leaves Path pointing at the directory itself",
+		},
+		{
+			name:        "single artifact with empty Args falls back to Path",
+			kind:        providers.KindModelArtifact,
+			pkgPath:     "/tmp/some-dir",
+			pkgArgs:     []string{},
+			wantTarget:  "/tmp/some-dir",
+			description: "robustness: resolver might omit Args under unusual circumstances",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pkg := &providers.ResolvedPackage{
-				Path: "/tmp/weights.pkl",
+				Path: tt.pkgPath,
+				Args: tt.pkgArgs,
 				Kind: tt.kind,
-				Name: "weights.pkl",
+				Name: "test-model",
 			}
 			resolver := &testutil.MockResolver{ResolveResult: pkg}
-			sast := &testutil.MockSASTAnalyzer{}
-			eng := newTestScanner(resolver, &testutil.MockMCPClient{},
-				&testutil.MockRuleMatcher{}, sast, &testutil.MockReporter{})
+			composer := &testutil.MockAIBOMComposer{
+				ScanResult: []providers.Finding{
+					{Rule: "aibom-pickle-dangerous-global", Severity: providers.SeverityCritical, Message: "os.system reference"},
+				},
+			}
 
-			_, err := eng.Scan("/tmp/weights.pkl", ScanOptions{})
-			if err == nil {
-				t.Fatal("expected error for model artifact kind, got nil")
+			eng := newTestScannerWithComposer(resolver, composer, nil)
+			report, err := eng.Scan("./input", ScanOptions{})
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
-			if got := err.Error(); !strings.Contains(got, "AIBOM") || !strings.Contains(got, "Day 9") {
-				t.Errorf("expected AIBOM/Day 9 in error message, got: %v", err)
+			if composer.ScanCount.Load() != 1 {
+				t.Errorf("expected 1 composer.Scan call, got %d", composer.ScanCount.Load())
 			}
-			if sast.AnalyzeDirectoryCount.Load() != 0 {
-				t.Errorf("SAST must not run for model artifacts, got %d calls",
-					sast.AnalyzeDirectoryCount.Load())
+			if composer.LastPath != tt.wantTarget {
+				t.Errorf("expected composer.Scan called with %q, got %q", tt.wantTarget, composer.LastPath)
+			}
+			if len(report.Findings) != 1 {
+				t.Fatalf("expected 1 finding from composer, got %d", len(report.Findings))
+			}
+			if report.Findings[0].Rule != "aibom-pickle-dangerous-global" {
+				t.Errorf("expected aibom-pickle-dangerous-global, got %q", report.Findings[0].Rule)
 			}
 		})
+	}
+}
+
+// TestScanner_Scan_ModelArtifact_NoMCPSidePipeline verifies that AIBOM
+// dispatch returns BEFORE any MCP-side analyzer runs. SAST patterns over
+// pickle bytes would produce nonsense findings, so the early return is
+// load-bearing for output quality, not just performance.
+func TestScanner_Scan_ModelArtifact_NoMCPSidePipeline(t *testing.T) {
+	pkg := &providers.ResolvedPackage{
+		Path: "/tmp/models",
+		Args: []string{"/tmp/models/weights.pkl"},
+		Kind: providers.KindModelArtifact,
+	}
+	resolver := &testutil.MockResolver{ResolveResult: pkg}
+	composer := &testutil.MockAIBOMComposer{}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mcpClient := &testutil.MockMCPClient{}
+	ruleMatcher := &testutil.MockRuleMatcher{}
+	sast := &testutil.MockSASTAnalyzer{}
+	depAuditor := &testutil.MockDepAuditor{}
+	hookAnalyzer := &testutil.MockHookAnalyzer{}
+	reporter := &testutil.MockReporter{}
+	suppressor := &testutil.MockSuppressor{}
+	eng := NewScanner(resolver, mcpClient, ruleMatcher, sast, depAuditor, hookAnalyzer, reporter, suppressor, nil, composer, logger)
+
+	_, err := eng.Scan("/tmp/models/weights.pkl", ScanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sast.AnalyzeDirectoryCount.Load() != 0 {
+		t.Errorf("SAST AnalyzeDirectory must not run for model artifacts, got %d calls", sast.AnalyzeDirectoryCount.Load())
+	}
+	if sast.DetectEgressCount.Load() != 0 {
+		t.Errorf("SAST DetectEgress must not run for model artifacts, got %d calls", sast.DetectEgressCount.Load())
+	}
+	if depAuditor.CallCount.Load() != 0 {
+		t.Errorf("DepAuditor must not run for model artifacts, got %d calls", depAuditor.CallCount.Load())
+	}
+	if hookAnalyzer.CallCount.Load() != 0 {
+		t.Errorf("HookAnalyzer must not run for model artifacts, got %d calls", hookAnalyzer.CallCount.Load())
+	}
+	if mcpClient.ConnectCount.Load() != 0 {
+		t.Errorf("MCPClient.Connect must not run for model artifacts, got %d calls", mcpClient.ConnectCount.Load())
+	}
+}
+
+// TestScanner_Scan_ModelArtifact_NoComposer_Errors verifies that scanning a
+// model artifact without a wired composer returns a descriptive error
+// instead of panicking on a nil pointer dereference. App always wires the
+// composer in InitEngines, so the nil branch is reserved for unit tests
+// that exercise the MCP-only flow.
+func TestScanner_Scan_ModelArtifact_NoComposer_Errors(t *testing.T) {
+	pkg := &providers.ResolvedPackage{
+		Path: "/tmp/models",
+		Args: []string{"/tmp/models/weights.pkl"},
+		Kind: providers.KindModelArtifact,
+	}
+	resolver := &testutil.MockResolver{ResolveResult: pkg}
+	// newTestScanner builds a scanner with composer=nil
+	eng := newTestScanner(resolver, &testutil.MockMCPClient{},
+		&testutil.MockRuleMatcher{}, &testutil.MockSASTAnalyzer{}, &testutil.MockReporter{})
+
+	_, err := eng.Scan("/tmp/models/weights.pkl", ScanOptions{})
+	if err == nil {
+		t.Fatal("expected error when composer is nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "AIBOMComposer") {
+		t.Errorf("expected error to mention AIBOMComposer, got: %v", err)
+	}
+}
+
+// TestScanner_Scan_ModelArtifact_SkipFlags verifies that the AIBOM skip
+// flags drop findings produced by the matching sub-provider after the
+// composer returns. Each rule-prefix family is gated independently.
+func TestScanner_Scan_ModelArtifact_SkipFlags(t *testing.T) {
+	allFindings := []providers.Finding{
+		{Rule: "aibom-pickle-dangerous-global", Severity: providers.SeverityCritical},
+		{Rule: "aibom-onnx-custom-domain", Severity: providers.SeverityWarning},
+		{Rule: "aibom-safetensors-malformed-header", Severity: providers.SeverityWarning},
+		{Rule: "aibom-modelcard-no-license", Severity: providers.SeverityWarning},
+		{Rule: "aibom-signature-missing", Severity: providers.SeverityWarning},
+	}
+
+	tests := []struct {
+		name      string
+		opts      ScanOptions
+		wantRules []string
+	}{
+		{
+			name: "no skip flags keeps all findings",
+			opts: ScanOptions{},
+			wantRules: []string{
+				"aibom-pickle-dangerous-global",
+				"aibom-onnx-custom-domain",
+				"aibom-safetensors-malformed-header",
+				"aibom-modelcard-no-license",
+				"aibom-signature-missing",
+			},
+		},
+		{
+			name: "SkipPickle drops only pickle findings",
+			opts: ScanOptions{SkipPickle: true},
+			wantRules: []string{
+				"aibom-onnx-custom-domain",
+				"aibom-safetensors-malformed-header",
+				"aibom-modelcard-no-license",
+				"aibom-signature-missing",
+			},
+		},
+		{
+			name: "SkipONNX drops only ONNX findings",
+			opts: ScanOptions{SkipONNX: true},
+			wantRules: []string{
+				"aibom-pickle-dangerous-global",
+				"aibom-safetensors-malformed-header",
+				"aibom-modelcard-no-license",
+				"aibom-signature-missing",
+			},
+		},
+		{
+			name: "SkipSafetensors drops only safetensors findings",
+			opts: ScanOptions{SkipSafetensors: true},
+			wantRules: []string{
+				"aibom-pickle-dangerous-global",
+				"aibom-onnx-custom-domain",
+				"aibom-modelcard-no-license",
+				"aibom-signature-missing",
+			},
+		},
+		{
+			name: "SkipModelCard drops only modelcard findings",
+			opts: ScanOptions{SkipModelCard: true},
+			wantRules: []string{
+				"aibom-pickle-dangerous-global",
+				"aibom-onnx-custom-domain",
+				"aibom-safetensors-malformed-header",
+				"aibom-signature-missing",
+			},
+		},
+		{
+			name: "SkipSignature drops only signature findings",
+			opts: ScanOptions{SkipSignature: true},
+			wantRules: []string{
+				"aibom-pickle-dangerous-global",
+				"aibom-onnx-custom-domain",
+				"aibom-safetensors-malformed-header",
+				"aibom-modelcard-no-license",
+			},
+		},
+		{
+			name:      "all skip flags drop everything",
+			opts:      ScanOptions{SkipPickle: true, SkipONNX: true, SkipSafetensors: true, SkipModelCard: true, SkipSignature: true},
+			wantRules: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &providers.ResolvedPackage{
+				Path: "/tmp/model-dir",
+				Kind: providers.KindModelDirectory,
+			}
+			resolver := &testutil.MockResolver{ResolveResult: pkg}
+			composer := &testutil.MockAIBOMComposer{ScanResult: allFindings}
+
+			eng := newTestScannerWithComposer(resolver, composer, nil)
+			report, err := eng.Scan("./model-dir", tt.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(report.Findings) != len(tt.wantRules) {
+				t.Fatalf("expected %d findings, got %d (%v)", len(tt.wantRules), len(report.Findings), report.Findings)
+			}
+			gotRules := make(map[string]bool, len(report.Findings))
+			for _, f := range report.Findings {
+				gotRules[f.Rule] = true
+			}
+			for _, want := range tt.wantRules {
+				if !gotRules[want] {
+					t.Errorf("expected rule %q in findings, got %v", want, report.Findings)
+				}
+			}
+		})
+	}
+}
+
+// TestScanner_Scan_ModelDirectory_HFTarget verifies that the HF resolver's
+// output (Kind=KindModelDirectory, Path pointing at the cache directory)
+// dispatches through the composer. Mirrors what `oxvault scan hf:org/model`
+// looks like end-to-end once the resolver returns.
+func TestScanner_Scan_ModelDirectory_HFTarget(t *testing.T) {
+	pkg := &providers.ResolvedPackage{
+		Path: "/home/u/.cache/oxvault/hf/microsoft__phi-3__main",
+		Kind: providers.KindModelDirectory,
+		Name: "phi-3",
+	}
+	resolver := &testutil.MockResolver{ResolveResult: pkg}
+	composer := &testutil.MockAIBOMComposer{
+		ScanResult: []providers.Finding{
+			{Rule: "aibom-modelcard-clean", Severity: providers.SeverityInfo},
+		},
+	}
+
+	eng := newTestScannerWithComposer(resolver, composer, nil)
+	report, err := eng.Scan("hf:microsoft/phi-3", ScanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if composer.LastPath != pkg.Path {
+		t.Errorf("expected composer to receive the cache directory %q, got %q", pkg.Path, composer.LastPath)
+	}
+	if len(report.Findings) != 1 || report.Findings[0].Rule != "aibom-modelcard-clean" {
+		t.Errorf("expected 1 modelcard-clean finding, got %v", report.Findings)
+	}
+}
+
+// TestScanner_Scan_ModelArtifact_SuppressionApplied verifies that the
+// suppressor is invoked for AIBOM scans the same way it is for MCP scans.
+// Without this, .oxvaultignore rules would silently be ignored on
+// model-artifact targets — a regression on the suppression contract.
+func TestScanner_Scan_ModelArtifact_SuppressionApplied(t *testing.T) {
+	pkg := &providers.ResolvedPackage{
+		Path: "/tmp/model-dir",
+		Kind: providers.KindModelDirectory,
+	}
+	resolver := &testutil.MockResolver{ResolveResult: pkg}
+
+	keptFinding := providers.Finding{Rule: "aibom-pickle-dangerous-global", Severity: providers.SeverityCritical}
+	suppressedFinding := providers.Finding{Rule: "aibom-modelcard-no-license", Severity: providers.SeverityWarning}
+
+	composer := &testutil.MockAIBOMComposer{
+		ScanResult: []providers.Finding{keptFinding, suppressedFinding},
+	}
+	suppressor := &testutil.MockSuppressor{
+		FilterKept:       []providers.Finding{keptFinding},
+		FilterSuppressed: []providers.Finding{suppressedFinding},
+	}
+
+	eng := newTestScannerWithComposer(resolver, composer, suppressor)
+	report, err := eng.Scan("./model-dir", ScanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if suppressor.LoadCount.Load() != 1 {
+		t.Errorf("expected LoadIgnoreFile to be called once, got %d", suppressor.LoadCount.Load())
+	}
+	if suppressor.FilterCount.Load() != 1 {
+		t.Errorf("expected Filter to be called once, got %d", suppressor.FilterCount.Load())
+	}
+	if len(report.Findings) != 1 || report.Findings[0].Rule != "aibom-pickle-dangerous-global" {
+		t.Errorf("expected 1 kept finding, got %v", report.Findings)
+	}
+	if len(report.Suppressed) != 1 || report.Suppressed[0].Rule != "aibom-modelcard-no-license" {
+		t.Errorf("expected 1 suppressed finding, got %v", report.Suppressed)
 	}
 }
 
@@ -793,7 +1112,7 @@ func newTestScannerWithProbe(
 	depAuditor := &testutil.MockDepAuditor{}
 	hookAnalyzer := &testutil.MockHookAnalyzer{}
 	suppressor := &testutil.MockSuppressor{}
-	return NewScanner(resolver, mcpClient, ruleMatcher, sast, depAuditor, hookAnalyzer, reporter, suppressor, probe, logger)
+	return NewScanner(resolver, mcpClient, ruleMatcher, sast, depAuditor, hookAnalyzer, reporter, suppressor, probe, nil, logger)
 }
 
 func TestScanner_ProbeNetwork_CallsProbe(t *testing.T) {

--- a/providers/export_test.go
+++ b/providers/export_test.go
@@ -8,3 +8,20 @@ package providers
 func SetONNXPanicHookForTest(fn func()) {
 	onnxPanicHookForTest = fn
 }
+
+// EffectivePickleMaxBytes exposes the analyzer's resolved max-file cap to
+// tests in the providers_test package. Only used to verify that
+// WithPickleMaxFileBytes clamps values per the documented contract.
+func EffectivePickleMaxBytes(p PickleAnalyzer) int64 {
+	if pa, ok := p.(*pickleAnalyzer); ok {
+		return pa.effectiveMaxBytes()
+	}
+	return -1
+}
+
+// PickleMaxFileBytesCeiling is the hard ceiling that WithPickleMaxFileBytes
+// clamps user input down to. Exported for assertion in clamp tests.
+func PickleMaxFileBytesCeiling() int64 {
+	return int64(maxFileBytes)
+}
+

--- a/providers/pickle.go
+++ b/providers/pickle.go
@@ -40,13 +40,53 @@ const (
 	maxInnerPickles   = 16      // Max pickle entries we descend into per ZIP archive
 )
 
-// pickleAnalyzer is the production PickleAnalyzer. It is stateless — every
+// pickleAnalyzer is the production PickleAnalyzer. It is stateless apart
+// from the configured outer-file size cap (maxFileBytes when zero) — every
 // call to AnalyzeFile / AnalyzeDirectory creates a fresh disassembler.
-type pickleAnalyzer struct{}
+type pickleAnalyzer struct {
+	// maxBytes overrides the default outer-file size cap. Zero falls through
+	// to maxFileBytes (2 GiB), which is also the safety upper bound — a
+	// caller asking for a larger cap is silently clamped back to the
+	// default to keep DoS guarantees intact.
+	maxBytes int64
+}
+
+// PickleAnalyzerOption configures the analyzer. Functional-option style
+// matches the rest of the AIBOM module (composer, signature verifier).
+type PickleAnalyzerOption func(*pickleAnalyzer)
+
+// WithPickleMaxFileBytes overrides the outer-file size cap (default 2 GiB).
+// Values <= 0 leave the default in place; values exceeding the 2 GiB
+// hard ceiling are clamped down so the DoS guard cannot be widened beyond
+// what the disassembler is tested against.
+func WithPickleMaxFileBytes(n int64) PickleAnalyzerOption {
+	return func(p *pickleAnalyzer) {
+		if n <= 0 {
+			return
+		}
+		if n > int64(maxFileBytes) {
+			n = int64(maxFileBytes)
+		}
+		p.maxBytes = n
+	}
+}
 
 // NewPickleAnalyzer returns a PickleAnalyzer.
-func NewPickleAnalyzer() PickleAnalyzer {
-	return &pickleAnalyzer{}
+func NewPickleAnalyzer(opts ...PickleAnalyzerOption) PickleAnalyzer {
+	p := &pickleAnalyzer{}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// effectiveMaxBytes returns the configured cap, falling back to the package
+// default when the analyzer was constructed without a custom value.
+func (p *pickleAnalyzer) effectiveMaxBytes() int64 {
+	if p.maxBytes <= 0 {
+		return int64(maxFileBytes)
+	}
+	return p.maxBytes
 }
 
 // AnalyzeFile reads the file at path, disassembles its pickle opcode stream,
@@ -55,7 +95,7 @@ func NewPickleAnalyzer() PickleAnalyzer {
 // Files that look like a ZIP archive (PyTorch save format) are unwrapped
 // transparently and the inner data.pkl is analysed instead.
 func (p *pickleAnalyzer) AnalyzeFile(path string) []Finding {
-	return analyzePickleFile(path, 0)
+	return analyzePickleFile(path, 0, p.effectiveMaxBytes())
 }
 
 // AnalyzeDirectory walks dir and analyses every pickle/torch file found.
@@ -65,6 +105,7 @@ func (p *pickleAnalyzer) AnalyzeFile(path string) []Finding {
 // makes the analyzer usable standalone.
 func (p *pickleAnalyzer) AnalyzeDirectory(dir string) []Finding {
 	var findings []Finding
+	max := p.effectiveMaxBytes()
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return nil
@@ -78,7 +119,7 @@ func (p *pickleAnalyzer) AnalyzeDirectory(dir string) []Finding {
 		if DetectArtifactFormat(path) != FormatPickle {
 			return nil
 		}
-		findings = append(findings, analyzePickleFile(path, 0)...)
+		findings = append(findings, analyzePickleFile(path, 0, max)...)
 		return nil
 	})
 	return findings
@@ -88,7 +129,14 @@ func (p *pickleAnalyzer) AnalyzeDirectory(dir string) []Finding {
 // outer-file size cap via io.LimitReader, and then dispatches to analyzePickleBytes
 // which enforces the recursion-depth guard for every code path (file → zip →
 // inner pickle).
-func analyzePickleFile(path string, depth int) []Finding {
+//
+// The effective cap is supplied by the caller so PickleAnalyzer instances
+// constructed with WithPickleMaxFileBytes can apply a tighter limit. A
+// zero or negative max falls back to the package default.
+func analyzePickleFile(path string, depth int, maxBytes int64) []Finding {
+	if maxBytes <= 0 {
+		maxBytes = int64(maxFileBytes)
+	}
 	f, err := os.Open(path) //nolint:gosec // path is filesystem-walk scoped to the scan target.
 	if err != nil {
 		return nil
@@ -96,13 +144,13 @@ func analyzePickleFile(path string, depth int) []Finding {
 	defer func() { _ = f.Close() }()
 
 	// Bounded read: peek one extra byte so we can detect oversize files.
-	limited := io.LimitReader(f, int64(maxFileBytes)+1)
+	limited := io.LimitReader(f, maxBytes+1)
 	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil
 	}
 
-	if int64(len(data)) > int64(maxFileBytes) {
+	if int64(len(data)) > maxBytes {
 		return []Finding{{
 			Rule:            "aibom-pickle-truncated",
 			Severity:        SeverityWarning,
@@ -111,7 +159,7 @@ func analyzePickleFile(path string, depth int) []Finding {
 			File:            path,
 			Message: fmt.Sprintf(
 				"pickle file exceeds %d-byte safety cap — disassembly skipped",
-				maxFileBytes),
+				maxBytes),
 			CWE: "CWE-1287",
 		}}
 	}

--- a/providers/pickle_test.go
+++ b/providers/pickle_test.go
@@ -492,3 +492,39 @@ func TestPickleAnalyzer_NonexistentFile(t *testing.T) {
 		t.Errorf("expected nil for missing file, got %+v", findings)
 	}
 }
+
+// TestWithPickleMaxFileBytes_Clamping pins the documented DoS-guard contract
+// for WithPickleMaxFileBytes:
+//   - n <= 0 leaves the default in place
+//   - n within [1, ceiling] is applied verbatim
+//   - n > ceiling clamps DOWN to ceiling (never widens the cap)
+func TestWithPickleMaxFileBytes_Clamping(t *testing.T) {
+	ceiling := providers.PickleMaxFileBytesCeiling()
+
+	tests := []struct {
+		name string
+		opt  int64
+		want int64
+	}{
+		{name: "no override", opt: 0, want: ceiling},
+		{name: "negative is no-op", opt: -1, want: ceiling},
+		{name: "small custom", opt: 1024, want: 1024},
+		{name: "exactly ceiling", opt: ceiling, want: ceiling},
+		{name: "above ceiling clamps down", opt: ceiling + 1, want: ceiling},
+		{name: "way above ceiling clamps down", opt: 1 << 62, want: ceiling},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p providers.PickleAnalyzer
+			if tt.opt == 0 {
+				p = providers.NewPickleAnalyzer()
+			} else {
+				p = providers.NewPickleAnalyzer(providers.WithPickleMaxFileBytes(tt.opt))
+			}
+			got := providers.EffectivePickleMaxBytes(p)
+			if got != tt.want {
+				t.Errorf("WithPickleMaxFileBytes(%d) effective = %d, want %d", tt.opt, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Day 9 of v0.4 AIBOM. End-to-end model artifact scans now functional.

## Summary
- Wired `AIBOMComposer` into the engine — `oxvault scan ./model.pkl`, `oxvault scan ./model-dir/`, and `oxvault scan hf:org/model` all run end-to-end through the composer.
- Added five `--skip-{pickle,onnx,safetensors,modelcard,signature}` flags, plus `--max-pickle-size`, `--trusted-issuers`, and `--additional-trusted-issuers`.
- App container exposes six new AIBOM providers via getters and functional options.

## Files
- `engines/scanner.go` — dispatch `KindModelArtifact` / `KindModelDirectory` to `aibomComposer.Scan()`; same suppression + report shape as MCP scans; new skip-flag filtering by rule prefix.
- `engines/scanner_test.go` — six new test groups covering dispatch, MCP-pipeline isolation, nil-composer error, skip flags (table test), HF target, and suppression.
- `app/app.go` — `aibomComposer` field + 5 sub-provider fields; `WithAIBOMComposer` + 5 sub-provider options (suffix-`Provider` to avoid colliding with `providers.WithPickleAnalyzer` etc.); `InitProviders` lazy-creates each + wires composer.
- `app/app_test.go` — three new tests covering AIBOM wiring, override preservation, default-composer construction.
- `config/config.go` — new `AIBOMOptions` struct (`MaxPickleBytes`, `TrustedIssuers`, `AdditionalTrustedIssuers`).
- `providers/pickle.go` — `PickleAnalyzerOption` + `WithPickleMaxFileBytes`; values clamped to the 2 GiB DoS ceiling.
- `cmd/main.go` — eight new scan flags + `splitAndTrimCSV` helper.
- `DEVLOG.md` — Day 9 entry.

## Test plan
- [x] `make build` clean
- [x] `make test` — 672 PASS subtests across all packages
- [x] `make lint` — 0 issues
- [x] `oxvault scan ./testdata/aibom/pickle/malicious/os_system.pkl` — emits `aibom-pickle-os-system` CRITICAL
- [x] `oxvault scan ./testdata/aibom/pickle/malicious/ --skip-pickle` — drops all `aibom-pickle-*`, surfaces signature findings
- [x] `oxvault scan ./testdata/aibom/pickle/malicious/ --skip-pickle --skip-signature` — only `aibom-modelcard-missing` survives

## Constraints honoured
- No new external deps.
- Match Day 7 / Day 8 style: functional options, lazy init, named returns where panic-recover matters.
- All quality gates green.