### PR TITLE
fix(scanner): correct artifact type for models and RAG (was always mcp)

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -252,7 +252,7 @@ func (a *agentLoop) poll() (*pendingJob, error) {
 	if err != nil {
 		return nil, fmt.Errorf("poll: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
 
 	switch resp.StatusCode {
@@ -371,8 +371,8 @@ func (a *agentLoop) resolveTarget(job *pendingJob) (string, error) {
 		}
 	}
 	return "", fmt.Errorf(
-		"could not locate artifact %q under %s (tried %d paths). "+
-			"Pass --target-map=%s=<path> to point the agent explicitly.",
+		"could not locate artifact %q under %s (tried %d paths); "+
+			"pass --target-map=%s=<path> to point the agent explicitly",
 		name, cwd, len(candidates), name,
 	)
 }
@@ -439,7 +439,7 @@ func (a *agentLoop) fetchArtifactName(artifactID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("artifact lookup %d: %s", resp.StatusCode, snippet(body, 256))
@@ -481,7 +481,7 @@ func (a *agentLoop) pushScan(f *lastscan.File) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("push %d: %s", resp.StatusCode, snippet(respBody, 256))
@@ -544,7 +544,7 @@ func (a *agentLoop) complete(jobID string, scanID *string, errMsg *string) error
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("complete %d: %s", resp.StatusCode, snippet(respBody, 256))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,13 +22,17 @@ import (
 // `oxvault push` can upload it without re-running. Best-effort.
 func persistLastScan(target string, report *engines.ScanReport, started, completed time.Time) error {
 	artifactName := deriveArtifactName(target)
-	artifactType := "mcp" // TODO: derive from resolver kind once Package is on report
+	artifactType := "mcp"
 	if report.Package != nil {
-		// e.g. KindModelArtifact / KindModelDirectory → "model"
-		switch fmt.Sprintf("%v", report.Package.Kind) {
-		case "model_artifact", "model_directory":
+		// Match against the typed PackageKind constants — comparing the
+		// stringified Kind to literals previously used underscores
+		// ("model_artifact") while the constants are hyphenated
+		// ("model-artifact"), so the switch never matched and every model
+		// / RAG artifact got tagged "mcp" on the dashboard.
+		switch report.Package.Kind {
+		case providers.KindModelArtifact, providers.KindModelDirectory:
 			artifactType = "model"
-		case "rag_corpus":
+		case providers.KindRAGCorpus:
 			artifactType = "rag"
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,22 +22,32 @@ import (
 // `oxvault push` can upload it without re-running. Best-effort.
 func persistLastScan(target string, report *engines.ScanReport, started, completed time.Time) error {
 	artifactName := deriveArtifactName(target)
-	artifactType := "mcp"
-	if report.Package != nil {
-		// Match against the typed PackageKind constants — comparing the
-		// stringified Kind to literals previously used underscores
-		// ("model_artifact") while the constants are hyphenated
-		// ("model-artifact"), so the switch never matched and every model
-		// / RAG artifact got tagged "mcp" on the dashboard.
-		switch report.Package.Kind {
-		case providers.KindModelArtifact, providers.KindModelDirectory:
-			artifactType = "model"
-		case providers.KindRAGCorpus:
-			artifactType = "rag"
-		}
-	}
+	artifactType := artifactTypeFor(report.Package)
 	f := lastscan.FromReport(target, artifactName, artifactType, started, completed, version, report.Findings)
 	return lastscan.Save(f)
+}
+
+// artifactTypeFor maps the resolver's PackageKind onto the platform's
+// dashboard artifact_type ("mcp" / "model" / "rag"). A nil package or any
+// unrecognised kind defaults to "mcp" to preserve the historical behaviour
+// of the scanner (MCP was the only artifact class before v0.4).
+//
+// Earlier this lived inline in persistLastScan as a stringified switch on
+// hyphenated literals like "model-artifact" — but the typed constants are
+// what we actually care about, and the explicit default makes the
+// fallback intentional and testable.
+func artifactTypeFor(pkg *providers.ResolvedPackage) string {
+	if pkg == nil {
+		return "mcp"
+	}
+	switch pkg.Kind {
+	case providers.KindModelArtifact, providers.KindModelDirectory:
+		return "model"
+	case providers.KindRAGCorpus:
+		return "rag"
+	default:
+		return "mcp"
+	}
 }
 
 // deriveArtifactName turns a scan target ("./node_modules/asana-mcp",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -3,7 +3,36 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"github.com/oxvault/scanner/providers"
 )
+
+// TestArtifactTypeFor pins the resolver-kind → dashboard-artifact-type
+// mapping. Regressions here ship as "every model tagged MCP on the
+// dashboard" — silent until someone notices the inventory list.
+func TestArtifactTypeFor(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  *providers.ResolvedPackage
+		want string
+	}{
+		{name: "nil package defaults to mcp", pkg: nil, want: "mcp"},
+		{name: "zero-value Kind defaults to mcp", pkg: &providers.ResolvedPackage{}, want: "mcp"},
+		{name: "explicit MCPServer", pkg: &providers.ResolvedPackage{Kind: providers.KindMCPServer}, want: "mcp"},
+		{name: "ModelArtifact (single file)", pkg: &providers.ResolvedPackage{Kind: providers.KindModelArtifact}, want: "model"},
+		{name: "ModelDirectory (HF download)", pkg: &providers.ResolvedPackage{Kind: providers.KindModelDirectory}, want: "model"},
+		{name: "RAGCorpus", pkg: &providers.ResolvedPackage{Kind: providers.KindRAGCorpus}, want: "rag"},
+		{name: "unknown future kind falls back to mcp", pkg: &providers.ResolvedPackage{Kind: providers.PackageKind("future-unknown")}, want: "mcp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := artifactTypeFor(tt.pkg)
+			if got != tt.want {
+				t.Errorf("artifactTypeFor(%+v) = %q, want %q", tt.pkg, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestSplitAndTrimCSV(t *testing.T) {
 	tests := []struct {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -192,7 +192,7 @@ func doPush(apiURL, consoleURL, apiKey string, scan *lastscan.File, quiet bool) 
 	if err != nil {
 		return fmt.Errorf("post /api/v1/scans: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {


### PR DESCRIPTION
## The bug

Every ML model and RAG artifact pushed to the platform was tagged \`artifact_type=\"mcp\"\` on the dashboard inventory. Visible as \`.onnx\`, \`.safetensors\`, \`.pkl\` files all showing **MCP** in the type column.

## Root cause

\`cmd/main.go:persistLastScan\` stringified \`PackageKind\` and matched against underscored literals:

\`\`\`go
switch fmt.Sprintf(\"%v\", report.Package.Kind) {
case \"model_artifact\", \"model_directory\":  // underscore ❌
    artifactType = \"model\"
case \"rag_corpus\":                          // underscore ❌
    artifactType = \"rag\"
}
\`\`\`

But \`providers/types.go\` uses **hyphens**:

\`\`\`go
KindModelArtifact   PackageKind = \"model-artifact\"
KindModelDirectory  PackageKind = \"model-directory\"
KindRAGCorpus       PackageKind = \"rag-corpus\"
\`\`\`

Switch never matched → always defaulted to \"mcp\".

## Fix

Compare against the typed constants directly. Removes the stringification + brittle string matching.

## Backfill note

Existing rows on the platform DB still carry \`artifact_type='mcp'\`. They self-correct on the next \`oxvault scan\` + \`oxvault push\` per affected artifact. If we want an instant fix, a one-off SQL on platform that infers type from the artifact name extension would do it.

## Test plan
- [x] \`make build\` passes
- [x] \`go test ./cmd/ ./providers/\` pass
- [ ] After merge: scan an \`.onnx\` file, \`oxvault push\`, verify dashboard inventory shows MODEL (not MCP)