### PR TITLE
fix(agent): use artifactTypeFor in processJob (was hardcoded mcp)

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -295,11 +295,15 @@ func (a *agentLoop) processJob(job *pendingJob, logf *agentLogger) error {
 	completedAt := time.Now().UTC()
 
 	// Persist + push the scan via the same code path as `oxvault push`.
+	// Type comes from the resolver's PackageKind, NOT a hardcoded "mcp" —
+	// otherwise every model + RAG rescan gets re-tagged as MCP on the
+	// dashboard, undoing the fix for the same bug in persistLastScan.
 	artifactName := job.ArtifactName
 	if artifactName == "" {
 		artifactName = deriveArtifactName(target)
 	}
-	f := lastscan.FromReport(target, artifactName, "mcp", startedAt, completedAt, version, report.Findings)
+	artifactType := artifactTypeFor(report.Package)
+	f := lastscan.FromReport(target, artifactName, artifactType, startedAt, completedAt, version, report.Findings)
 	if err := lastscan.Save(f); err != nil {
 		return fmt.Errorf("persist last scan: %w", err)
 	}


### PR DESCRIPTION
## Why

PR #42 fixed the artifact-type tagging bug for the \`oxvault scan\` → \`oxvault push\` path. But rescans triggered from the dashboard's Re-scan button go through the **agent**'s \`processJob\`, which had its own inlined hardcode:

\`\`\`go
f := lastscan.FromReport(target, artifactName, \"mcp\", startedAt, ...)
//                                              ↑↑↑↑↑ hardcoded
\`\`\`

So every rescan kicked off from the dashboard re-stamped models and RAG artifacts as MCP, silently undoing PR #42 for the path users actually hit most.

## Fix

Use the \`artifactTypeFor(report.Package)\` helper that #42 added. Single-line behavioural change.

## Test plan
- [x] \`make build\` passes
- [x] \`make lint\` passes (0 issues)
- [x] \`go test ./cmd/\` passes
- [ ] After merge: rebuild agent binary, click Re-scan on an .onnx artifact in the dashboard, confirm the row flips to MODEL type