### PR TITLE
fix(agent): resolve remote-scheme targets (npm / HF / github) for Re-scan

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -402,16 +403,17 @@ func isRemoteSchemeTarget(name string) bool {
 		strings.HasPrefix(name, "@") {
 		return true
 	}
-	// `org/pkg` is the npm bare-form for scoped-like names without `@`,
-	// e.g. `mcpotato/42-eicar-street`. Accept any single `/` not at edges.
-	if i := strings.Index(name, "/"); i > 0 && i < len(name)-1 && !strings.ContainsAny(name, "\\") {
-		// One slash only — keep the safety net tight.
-		if strings.Count(name, "/") == 1 {
-			return true
-		}
-	}
-	return false
+	// Bare-form `org/pkg` (e.g. `mcpotato/42-eicar-street`). Match the npm
+	// package naming charset on both sides of a single slash so malformed
+	// pseudo-schemes like `:foo/bar` or `foo/bar/baz` don't get classified
+	// as remote and incorrectly handed to the scanner's npm/HF resolver.
+	return barePackageRe.MatchString(name)
 }
+
+// barePackageRe matches `<segment>/<segment>` where each segment is one or
+// more npm-safe characters (alphanumeric, dot, underscore, hyphen). One
+// slash exactly, no leading/trailing slash, no colons or other weirdness.
+var barePackageRe = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
 
 // validateArtifactName rejects names that could escape cwd when joined
 // to it (path traversal). The agent never trusts the platform's name

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -359,8 +359,17 @@ func (a *agentLoop) resolveTarget(job *pendingJob) (string, error) {
 		return "", err
 	}
 
+	// Explicit --target-map entry always wins (lets the user pin a remote
+	// name to a local checkout for offline-mode rescans).
 	if t, ok := a.targets[name]; ok {
 		return t, nil
+	}
+
+	// Remote-scheme artifacts skip the local-filesystem probe entirely —
+	// the scanner's own resolver handles them (npm install, HF download,
+	// git clone). Pass the name through verbatim.
+	if isRemoteSchemeTarget(name) {
+		return name, nil
 	}
 
 	cwd, err := os.Getwd()
@@ -381,10 +390,34 @@ func (a *agentLoop) resolveTarget(job *pendingJob) (string, error) {
 	)
 }
 
+// isRemoteSchemeTarget reports whether the artifact name should be passed
+// straight to the scanner's resolver instead of looked up on the local
+// filesystem. Covers npm packages (`@scope/pkg` and bare names with a slash
+// like `org/pkg`), HuggingFace (`hf:org/model`), and GitHub (`github:user/repo`).
+// Bare npm names without a slash (e.g. `playwright`) still go through the
+// local-FS probe first — the resolver falls back to npm if not found.
+func isRemoteSchemeTarget(name string) bool {
+	if strings.HasPrefix(name, "hf:") ||
+		strings.HasPrefix(name, "github:") ||
+		strings.HasPrefix(name, "@") {
+		return true
+	}
+	// `org/pkg` is the npm bare-form for scoped-like names without `@`,
+	// e.g. `mcpotato/42-eicar-street`. Accept any single `/` not at edges.
+	if i := strings.Index(name, "/"); i > 0 && i < len(name)-1 && !strings.ContainsAny(name, "\\") {
+		// One slash only — keep the safety net tight.
+		if strings.Count(name, "/") == 1 {
+			return true
+		}
+	}
+	return false
+}
+
 // validateArtifactName rejects names that could escape cwd when joined
 // to it (path traversal). The agent never trusts the platform's name
-// blindly — see resolveTarget. Tested with names from real CLI corpora
-// (mcp-server, @scope/pkg, hf:org/model resolved to "model").
+// blindly — see resolveTarget. Allows scheme-style names that the
+// scanner's resolver handles (hf:org/model, @scope/pkg, github:user/repo)
+// while still rejecting path-traversal patterns.
 func validateArtifactName(name string) error {
 	if name == "" {
 		return fmt.Errorf("artifact name is empty")
@@ -392,12 +425,18 @@ func validateArtifactName(name string) error {
 	if strings.HasPrefix(name, ".") {
 		return fmt.Errorf("artifact name %q starts with '.'", name)
 	}
-	if strings.ContainsAny(name, "/\\") {
-		return fmt.Errorf("artifact name %q contains path separator", name)
+	if strings.HasPrefix(name, "/") {
+		return fmt.Errorf("artifact name %q is an absolute path", name)
+	}
+	if strings.ContainsAny(name, "\\") {
+		return fmt.Errorf("artifact name %q contains backslash", name)
 	}
 	if strings.Contains(name, "..") {
 		return fmt.Errorf("artifact name %q contains '..'", name)
 	}
+	// Forward slashes are allowed (HF, npm-scoped, github scheme all use
+	// them) — but only via the remote-scheme branch in resolveTarget;
+	// they never get joined to cwd for a filesystem probe.
 	return nil
 }
 

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -18,6 +18,13 @@ func TestValidateArtifactName(t *testing.T) {
 		"my_server",
 		"server.v2",
 		"@scope_pkg",
+		// Remote-scheme targets that the scanner's resolver handles —
+		// the agent passes them through verbatim instead of joining to cwd
+		// (see resolveTarget + isRemoteSchemeTarget).
+		"hf:mcpotato/42-eicar-street",
+		"github:user/repo",
+		"@playwright/mcp",
+		"mcpotato/42-eicar-street",
 	}
 	for _, name := range good {
 		if err := validateArtifactName(name); err != nil {
@@ -26,15 +33,15 @@ func TestValidateArtifactName(t *testing.T) {
 	}
 
 	bad := map[string]string{
-		"":                "empty",
-		".":               "leading dot",
-		"..":              "leading dot",
-		"../escape":       "path separator",
-		"../../etc/shadow":"path separator",
-		"a/b":             "path separator",
-		"a\\b":            "backslash",
-		"foo..bar":        "embedded ..",
-		".hidden":         "leading dot",
+		"":                  "empty",
+		".":                 "leading dot",
+		"..":                "leading dot",
+		"../escape":         "embedded ..",
+		"../../etc/shadow":  "embedded ..",
+		"/etc/passwd":       "absolute path",
+		"a\\b":              "backslash",
+		"foo..bar":          "embedded ..",
+		".hidden":           "leading dot",
 	}
 	for name, why := range bad {
 		if err := validateArtifactName(name); err == nil {
@@ -69,6 +76,39 @@ func TestParseTargetMaps(t *testing.T) {
 	for _, s := range bad {
 		if _, err := parseTargetMaps([]string{s}); err == nil {
 			t.Errorf("parseTargetMaps(%q) = nil, want error", s)
+		}
+	}
+}
+
+// TestIsRemoteSchemeTarget pins which artifact names the agent forwards
+// to the scanner's resolver verbatim (vs. trying to locate locally).
+// Regression here ships as a Re-scan button that fails with "could not
+// locate artifact" on every npm / HF / GitHub target.
+func TestIsRemoteSchemeTarget(t *testing.T) {
+	t.Parallel()
+	remote := []string{
+		"hf:mcpotato/42-eicar-street",
+		"hf:openai/clip-vit-base-patch32",
+		"github:user/repo",
+		"@playwright/mcp",
+		"@anthropic/mcp-server",
+		"mcpotato/42-eicar-street", // bare npm form, single slash
+	}
+	for _, n := range remote {
+		if !isRemoteSchemeTarget(n) {
+			t.Errorf("isRemoteSchemeTarget(%q) = false, want true", n)
+		}
+	}
+	local := []string{
+		"asana-mcp",
+		"cmd-injection",
+		"server.v2",
+		"my_server",
+		"garbage.onnx", // file basename, no slash → local probe
+	}
+	for _, n := range local {
+		if isRemoteSchemeTarget(n) {
+			t.Errorf("isRemoteSchemeTarget(%q) = true, want false", n)
 		}
 	}
 }

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -105,6 +105,15 @@ func TestIsRemoteSchemeTarget(t *testing.T) {
 		"server.v2",
 		"my_server",
 		"garbage.onnx", // file basename, no slash → local probe
+		// Malformed pseudo-schemes that the bare-form branch must NOT
+		// classify as remote (would otherwise get handed to the npm
+		// resolver and produce confusing errors).
+		":foo/bar",
+		"foo:/bar",
+		"foo/bar/baz",
+		"/foo/bar",
+		"foo/",
+		"/foo",
 	}
 	for _, n := range local {
 		if isRemoteSchemeTarget(n) {


### PR DESCRIPTION
## The bug

Dashboard Re-scan button failed with:
\`\`\`
resolve target: could not locate artifact \"github-mcp-server\" under
/root/Code/oxvault/scanner (tried 4 paths); pass
--target-map=github-mcp-server=<path> to point the agent explicitly
\`\`\`
Same error for \`hf:mcpotato/42-eicar-street\`, \`@playwright/mcp\`, etc.

## Root cause

Two layered bugs in \`cmd/agent.go\`:

1. **\`validateArtifactName\` rejected any \`/\`** — so \`hf:org/model\`, \`@scope/pkg\`, and bare-npm \`org/pkg\` (e.g. \`mcpotato/42-eicar-street\`) failed validation before reaching the scanner.
2. **\`resolveTarget\` only did local-filesystem probes** — even when the name was clearly a remote-resolver target (npm package, HF model, GitHub repo). The scanner already knows how to npm-install / HF-download / git-clone these — the agent should just pass them through.

## Fix

- Loosen \`validateArtifactName\`: keep \`..\`, backslash, leading-dot, and absolute-path rejections. Allow forward slashes for scheme / scope forms — they never get joined to \`cwd\` thanks to the next bit.
- Add \`isRemoteSchemeTarget(name)\` — returns true for \`hf:*\`, \`github:*\`, \`@scope/*\`, and bare \`org/pkg\` (single slash, non-edge).
- \`resolveTarget\`: when a name is a remote-scheme target, return the name verbatim and let the scanner handle the resolution.

## Tests

- \`TestValidateArtifactName\` — add the 4 remote-scheme good cases, swap \`a/b\` (no longer rejected) for the still-rejected \`/etc/passwd\`.
- \`TestIsRemoteSchemeTarget\` — new. 6 remote / 5 local cases pinning the contract so regressions here can't silently break Re-scan.

## Test plan
- [x] \`go test ./cmd/\` all pass
- [x] \`make lint\` 0 issues
- [ ] After merge: click Re-scan on \`github-mcp-server\` on the dashboard, confirm agent picks up the job and scan completes
- [ ] Click Re-scan on \`hf:mcpotato/42-eicar-street\`, confirm CRITICAL is re-detected