### PR TITLE
feat(cli): add `oxvault login` command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/oxvault/scanner/internal/userconfig"
+	"github.com/spf13/cobra"
+)
+
+// newLoginCmd builds `oxvault login` - the first step of the onboarding flow
+// (create key in the Console → login → scan → push). It validates a
+// workspace-scoped API key against the platform, then persists it to
+// ~/.oxvault/config.toml so subsequent `scan --push` / `push` runs pick it up
+// without re-typing flags.
+//
+// The key is resolved in priority order: --api-key flag → OXVAULT_API_KEY env
+// → interactive prompt read from /dev/tty (so it never lands in shell history
+// as a command argument).
+func newLoginCmd() *cobra.Command {
+	var (
+		apiKey     string
+		apiURL     string
+		consoleURL string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate the CLI with the Oxvault platform",
+		Long: `Validate a workspace API key against the Oxvault platform and store it
+locally so 'oxvault push' (and 'oxvault scan --push') work without flags.
+
+Mint a key in the Console at /settings/api-keys, then:
+
+  Examples:
+    oxvault login                                  # prompt for the key (hidden from shell history)
+    oxvault login --api-key ox_…
+    OXVAULT_API_KEY=ox_… oxvault login
+    oxvault login --api-key ox_… --api-url http://localhost:8080
+
+The key is verified via GET <api-url>/api/v1/auth/me before anything is
+written - an invalid key exits non-zero and leaves the config untouched. On
+success the key is saved to ~/.oxvault/config.toml under [push].`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLoginFlow(apiKey, apiURL, consoleURL, readAPIKeyFromTTY)
+		},
+	}
+
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "Workspace API key (default: prompt, or $OXVAULT_API_KEY)")
+	cmd.Flags().StringVar(&apiURL, "api-url", "", "Platform base URL (default: $OXVAULT_API_URL or "+defaultAPIURL+")")
+	cmd.Flags().StringVar(&consoleURL, "console-url", "", "Console base URL (default: $OXVAULT_CONSOLE_URL or "+defaultConsoleURL+")")
+
+	return cmd
+}
+
+// meResponse is the subset of the platform's GET /api/v1/auth/me payload
+// (models.MeResponse) that we surface in the success banner.
+type meResponse struct {
+	User struct {
+		Email string `json:"email"`
+	} `json:"user"`
+	Workspace struct {
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	} `json:"workspace"`
+}
+
+// runLoginFlow resolves the key + URLs, validates the key against the
+// platform, and persists it only on success. prompt is injected so tests can
+// exercise the interactive path without a real terminal.
+func runLoginFlow(apiKey, apiURL, consoleURL string, prompt func() (string, error)) error {
+	// 1. Resolve the key: flag → env → interactive prompt.
+	if apiKey == "" {
+		apiKey = os.Getenv("OXVAULT_API_KEY")
+	}
+	if apiKey == "" {
+		got, err := prompt()
+		if err != nil {
+			return err
+		}
+		apiKey = got
+	}
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return fmt.Errorf("no API key provided (pass --api-key, set OXVAULT_API_KEY, or enter it when prompted)")
+	}
+	if !strings.HasPrefix(apiKey, "ox_") {
+		return fmt.Errorf("api key looks malformed (expected prefix \"ox_\"); refusing to send")
+	}
+
+	// 2. Resolve URLs: flag → env → shared default.
+	if apiURL == "" {
+		apiURL = os.Getenv("OXVAULT_API_URL")
+	}
+	if apiURL == "" {
+		apiURL = defaultAPIURL
+	}
+	if consoleURL == "" {
+		consoleURL = os.Getenv("OXVAULT_CONSOLE_URL")
+	}
+	if consoleURL == "" {
+		consoleURL = deriveConsoleURL(apiURL)
+	}
+
+	// 3. Validate BEFORE persisting anything.
+	me, err := verifyAPIKey(apiURL, apiKey)
+	if err != nil {
+		return err
+	}
+
+	// 4. Persist only on success.
+	if err := saveLoginConfig(apiKey, apiURL, consoleURL); err != nil {
+		return err
+	}
+
+	path, _ := userconfig.Path()
+	printLoginSuccess(me, apiKey, path)
+	return nil
+}
+
+// verifyAPIKey calls GET <apiURL>/api/v1/auth/me with the key in the Bearer
+// header. The platform dispatches on the "ox_" prefix, so a workspace key is
+// accepted here just like a session JWT. 200 → valid; 401/403 → invalid key.
+func verifyAPIKey(apiURL, apiKey string) (*meResponse, error) {
+	endpoint, err := url.JoinPath(apiURL, "/api/v1/auth/me")
+	if err != nil {
+		return nil, fmt.Errorf("build endpoint: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("User-Agent", "oxvault-cli/"+version)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get /api/v1/auth/me: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var me meResponse
+		if err := json.Unmarshal(body, &me); err != nil {
+			return nil, fmt.Errorf("parse /api/v1/auth/me response: %w\nbody: %s", err, snippet(body, 256))
+		}
+		return &me, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, fmt.Errorf("invalid API key: the platform rejected it (%d); mint a fresh key at <console>/settings/api-keys", resp.StatusCode)
+	default:
+		return nil, formatHTTPError(resp.StatusCode, body)
+	}
+}
+
+// saveLoginConfig merges the credential into ~/.oxvault/config.toml, leaving
+// unrelated settings (e.g. [push].auto / quiet) intact. A missing or corrupt
+// file starts from a fresh Config so login always succeeds in writing.
+func saveLoginConfig(apiKey, apiURL, consoleURL string) error {
+	uc, err := userconfig.Load()
+	if err != nil || uc == nil {
+		uc = &userconfig.Config{}
+	}
+	uc.Push.APIKey = apiKey
+	uc.Push.APIURL = apiURL
+	uc.Push.ConsoleURL = consoleURL
+	return userconfig.Save(uc)
+}
+
+// readAPIKeyFromTTY prompts on stderr and reads a single line from /dev/tty -
+// not stdin - so the key is never taken from a pipe and never appears in shell
+// history. Mirrors the gateway's TTY-read pattern.
+func readAPIKeyFromTTY() (string, error) {
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		return "", fmt.Errorf("no API key provided and no interactive terminal available; pass --api-key or set OXVAULT_API_KEY")
+	}
+	defer func() { _ = tty.Close() }()
+
+	fmt.Fprint(os.Stderr, "Enter your Oxvault API key (ox_…): ")
+	var key string
+	if _, err := fmt.Fscanln(tty, &key); err != nil {
+		return "", fmt.Errorf("read API key from terminal: %w", err)
+	}
+	return strings.TrimSpace(key), nil
+}
+
+// redactKey returns a display-safe form of an API key: the "ox_" prefix and
+// the last four characters only. The full key is never logged.
+func redactKey(k string) string {
+	if len(k) <= 8 {
+		return "ox_…"
+	}
+	return k[:3] + "…" + k[len(k)-4:]
+}
+
+func printLoginSuccess(me *meResponse, apiKey, path string) {
+	bold := color.New(color.Bold)
+	dim := color.New(color.Faint)
+	emerald := color.New(color.FgGreen, color.Bold)
+
+	who := me.User.Email
+	if me.Workspace.Name != "" {
+		who = fmt.Sprintf("%s (workspace %s)", me.User.Email, me.Workspace.Name)
+	}
+
+	fmt.Fprintf(os.Stderr, "\n  %s %s\n",
+		emerald.Sprint("✓"),
+		bold.Sprintf("Logged in as %s", who))
+	fmt.Fprintf(os.Stderr, "  %s %s\n", dim.Sprint("Key:   "), redactKey(apiKey))
+	fmt.Fprintf(os.Stderr, "  %s %s\n\n", dim.Sprint("Config:"), path)
+}

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oxvault/scanner/internal/userconfig"
+)
+
+// meServer spins up an httptest server standing in for the platform's
+// GET /api/v1/auth/me. It records the Bearer token it last received and
+// responds with status/body driven by the caller.
+type meServer struct {
+	*httptest.Server
+	gotAuth string
+}
+
+func newMeServer(t *testing.T, status int) *meServer {
+	t.Helper()
+	ms := &meServer{}
+	ms.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/me" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		ms.gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"user":      map[string]any{"email": "dev@oxvault.dev"},
+				"workspace": map[string]any{"name": "Acme", "slug": "acme"},
+			})
+		}
+	}))
+	t.Cleanup(ms.Close)
+	return ms
+}
+
+// isolateConfig points userconfig at a throwaway path and clears every env
+// var the login flow reads, so tests never touch the real ~/.oxvault or leak
+// the developer's shell environment into resolution.
+func isolateConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("OXVAULT_CONFIG", path)
+	t.Setenv("OXVAULT_API_KEY", "")
+	t.Setenv("OXVAULT_API_URL", "")
+	t.Setenv("OXVAULT_CONSOLE_URL", "")
+	return path
+}
+
+// failPrompt is the injected prompt for cases where it must NOT be called.
+func failPrompt(t *testing.T) func() (string, error) {
+	t.Helper()
+	return func() (string, error) {
+		t.Fatal("prompt should not have been called")
+		return "", nil
+	}
+}
+
+func TestRunLoginFlow_KeyResolutionPrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		flagKey    string
+		envKey     string
+		prompt     func() (string, error)
+		wantBearer string
+	}{
+		{
+			name:       "flag wins over env and prompt",
+			flagKey:    "ox_flagkey1234",
+			envKey:     "ox_envkey1234",
+			prompt:     func() (string, error) { return "ox_promptkey1234", nil },
+			wantBearer: "Bearer ox_flagkey1234",
+		},
+		{
+			name:       "env wins over prompt when no flag",
+			flagKey:    "",
+			envKey:     "ox_envkey1234",
+			prompt:     func() (string, error) { return "ox_promptkey1234", nil },
+			wantBearer: "Bearer ox_envkey1234",
+		},
+		{
+			name:       "prompt used when flag and env empty",
+			flagKey:    "",
+			envKey:     "",
+			prompt:     func() (string, error) { return "ox_promptkey1234", nil },
+			wantBearer: "Bearer ox_promptkey1234",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateConfig(t)
+			if tt.envKey != "" {
+				t.Setenv("OXVAULT_API_KEY", tt.envKey)
+			}
+			srv := newMeServer(t, http.StatusOK)
+
+			err := runLoginFlow(tt.flagKey, srv.URL, "", tt.prompt)
+			if err != nil {
+				t.Fatalf("runLoginFlow: unexpected error: %v", err)
+			}
+			if srv.gotAuth != tt.wantBearer {
+				t.Errorf("bearer sent = %q, want %q", srv.gotAuth, tt.wantBearer)
+			}
+		})
+	}
+}
+
+func TestRunLoginFlow_RejectsBadPrefix(t *testing.T) {
+	path := isolateConfig(t)
+	// No server should be hit; a call would fail the URL join / request but
+	// the prefix guard must fire first. Use a bogus URL to be sure.
+	err := runLoginFlow("badkey123", "http://127.0.0.1:0", "", failPrompt(t))
+	if err == nil {
+		t.Fatal("expected error for non-ox_ key")
+	}
+	if !strings.Contains(err.Error(), "ox_") {
+		t.Errorf("error = %q, want it to mention the ox_ prefix", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("config must not be written on prefix rejection (stat err = %v)", statErr)
+	}
+}
+
+func TestRunLoginFlow_ValidWritesConfig(t *testing.T) {
+	path := isolateConfig(t)
+	srv := newMeServer(t, http.StatusOK)
+
+	err := runLoginFlow("ox_validkey1234", srv.URL, "", failPrompt(t))
+	if err != nil {
+		t.Fatalf("runLoginFlow: unexpected error: %v", err)
+	}
+
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("expected config written at %s: %v", path, statErr)
+	}
+	uc, err := userconfig.Load()
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if uc.Push.APIKey != "ox_validkey1234" {
+		t.Errorf("api_key = %q, want ox_validkey1234", uc.Push.APIKey)
+	}
+	if uc.Push.APIURL != srv.URL {
+		t.Errorf("api_url = %q, want %q", uc.Push.APIURL, srv.URL)
+	}
+	if uc.Push.ConsoleURL == "" {
+		t.Error("console_url must be populated")
+	}
+}
+
+func TestRunLoginFlow_InvalidKeyDoesNotWrite(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			path := isolateConfig(t)
+			srv := newMeServer(t, status)
+
+			err := runLoginFlow("ox_invalidkey1234", srv.URL, "", failPrompt(t))
+			if err == nil {
+				t.Fatal("expected error for rejected key")
+			}
+			if !strings.Contains(err.Error(), "invalid API key") {
+				t.Errorf("error = %q, want it to mention invalid API key", err)
+			}
+			if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+				t.Errorf("config must not be written on auth failure (stat err = %v)", statErr)
+			}
+		})
+	}
+}
+
+func TestRunLoginFlow_PreservesExistingSettings(t *testing.T) {
+	path := isolateConfig(t)
+	// Pre-seed a config with auto=true; login must keep it.
+	seed := &userconfig.Config{}
+	seed.Push.Auto = true
+	seed.Push.APIKey = "ox_oldkey1234"
+	if err := userconfig.Save(seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	srv := newMeServer(t, http.StatusOK)
+	if err := runLoginFlow("ox_newkey5678", srv.URL, "", failPrompt(t)); err != nil {
+		t.Fatalf("runLoginFlow: %v", err)
+	}
+
+	uc, err := userconfig.Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !uc.Push.Auto {
+		t.Error("existing [push].auto=true was clobbered")
+	}
+	if uc.Push.APIKey != "ox_newkey5678" {
+		t.Errorf("api_key = %q, want ox_newkey5678", uc.Push.APIKey)
+	}
+	_ = path
+}
+
+func TestRedactKey(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"ox_abcdef1234", "ox_…1234"},
+		{"ox_short", "ox_…"},
+		{"", "ox_…"},
+	}
+	for _, tt := range tests {
+		if got := redactKey(tt.in); got != tt.want {
+			t.Errorf("redactKey(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+		if tt.in != "" && len(tt.in) > 8 && strings.Contains(redactKey(tt.in), tt.in) {
+			t.Errorf("redactKey leaked the full key for %q", tt.in)
+		}
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,6 +86,7 @@ func main() {
 		newScanCmd(),
 		newPinCmd(),
 		newCheckCmd(),
+		newLoginCmd(),
 		newPushCmd(),
 		newInitCmd(),
 		newAgentCmd(),

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -17,6 +17,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// defaultAPIURL / defaultConsoleURL are the shared platform fallbacks used by
+// `push`, `login`, and `init` when no flag, env var, or config value is set.
+// Defined once here so the subcommands never drift apart.
+const (
+	defaultAPIURL     = "https://platform.oxvault.dev"
+	defaultConsoleURL = "https://console.oxvault.dev"
+)
+
 // newPushCmd builds `oxvault push` — uploads the most recent local scan to
 // the Oxvault platform. Source of truth is ~/.oxvault/last-scan.json,
 // written by `oxvault scan` after every successful run.
@@ -96,7 +104,7 @@ func runPushFlow(scan *lastscan.File, apiKey, apiURL, consoleURL string, quiet b
 		apiURL = uc.Push.APIURL
 	}
 	if apiURL == "" {
-		apiURL = "https://platform.oxvault.dev"
+		apiURL = defaultAPIURL
 	}
 
 	if consoleURL == "" {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/fatih/color v1.19.0
+	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -12,7 +13,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/userconfig/userconfig.go
+++ b/internal/userconfig/userconfig.go
@@ -74,3 +74,28 @@ func Load() (*Config, error) {
 	}
 	return cfg, nil
 }
+
+// Save writes cfg to disk at Path() as TOML, creating the parent directory
+// if needed.
+//
+// The directory is created 0700 and the file 0600: [push].api_key holds a
+// workspace secret ("ox_...") and must not be readable by other local
+// accounts. Callers that want to preserve unrelated existing settings should
+// Load first, mutate, then Save.
+func Save(cfg *Config) error {
+	p, err := Path()
+	if err != nil {
+		return err
+	}
+	data, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("userconfig: marshal config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return fmt.Errorf("userconfig: create config dir: %w", err)
+	}
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		return fmt.Errorf("userconfig: write %s: %w", p, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Why

Onboarding is: create an API key in the Console → `oxvault login --api-key ox_…` → `oxvault scan` → `oxvault push`. The CLI had `init`/`push`/`agent`/`upgrade` but **no `login`** — this adds it.

## Behavior

`oxvault login`:
- Resolves the key in priority order: `--api-key` flag → `OXVAULT_API_KEY` env → interactive prompt read from `/dev/tty` (mirrors the gateway's TTY pattern, so the key never lands in shell history as an argument).
- Rejects keys not prefixed `ox_` **up front** (mirrors `push.go`).
- **Validates before storing:** `GET <api-url>/api/v1/auth/me` with `Authorization: Bearer <ox_key>`. The platform dispatches on the `ox_` prefix. `200` → valid; `401/403` → clear "invalid API key" error, exit non-zero, **config untouched**.
- Optional `--api-url` (default `https://platform.oxvault.dev`) and `--console-url` (default `https://console.oxvault.dev`), each overridable via `$OXVAULT_API_URL` / `$OXVAULT_CONSOLE_URL`. The default platform URL is now a **shared constant** reused by `push` (no duplicated literal).
- On success: persists `api_key` / `api_url` / `console_url` to `~/.oxvault/config.toml` under `[push]` via `internal/userconfig` (the same store `init`/`push` read), preserving unrelated settings (e.g. `[push].auto`). Prints `Logged in as <email> (workspace <name>)`, the config path, and a **redacted** key (`ox_…<last4>`).

## Implementation notes

- `internal/userconfig`: new `Save()` — `0700` dir / `0600` file because the key is a secret; Load-mutate-Save to preserve existing config.
- `cmd/push.go`: extracted `defaultAPIURL` / `defaultConsoleURL` constants.
- Registered in `cmd/main.go` grouped before `push`.
- Never logs the full key.

## Tests (`cmd/login_test.go`)

Table-driven, run with `-race`, using `httptest`:
- flag > env > prompt precedence (asserts the Bearer actually sent)
- prompt fallback when flag + env empty
- `ox_` prefix rejection — no HTTP call, no config written
- valid `200` → config written with correct `[push]` keys
- `401`/`403` → error, config file does **not** exist
- existing `[push].auto` preserved across login
- `redactKey` never leaks the full key

## Quality gates

`gofmt`, `make build`, `make check` (build + test + lint, `0 issues`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)