### PR TITLE
feat(resolver): github:owner/repo/subpath with sparse fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Every artifact your AI agent loads is untrusted code or data. **MCP servers** ex
 
 ```bash
 curl -fsSL https://oxvault.dev/install.sh | sh
-oxvault scan github:user/mcp-server      # MCP server
+oxvault scan github:user/mcp-server      # MCP server (whole repo)
+oxvault scan github:user/repo/path/to/server  # sub-directory only (sparse)
 oxvault scan ./model.pkl                 # ML model artifact
 oxvault scan hf:org/model                # Hugging Face model
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,6 +211,7 @@ Targets:
   ./my-server                    Local project directory or file
   @company/mcp-server            npm package (downloaded to temp dir)
   github:user/repo               GitHub repository (cloned)
+  github:user/repo/sub/dir       GitHub sub-directory (sparse-fetched)
 
 Config-based scanning:
   --config ~/.claude/claude_desktop_config.json   Scan all servers in a config file

--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -6,9 +6,25 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 )
+
+// gitHubRepoURL builds the HTTPS clone URL for an owner/repo. It is a package
+// variable so tests can point it at a local bare repository and remain
+// hermetic (no real network / github access).
+var gitHubRepoURL = func(owner, repo string) string {
+	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+}
+
+// githubTarget is the parsed form of a `github:` scan target.
+type githubTarget struct {
+	owner   string // repository owner / org
+	repo    string // repository name
+	subpath string // optional sub-directory to scan (cleaned, "" when absent)
+	ref     string // optional branch or tag (@ref), "" when absent
+}
 
 type resolver struct {
 	logger *slog.Logger
@@ -135,31 +151,197 @@ func (r *resolver) resolveNPM(packageName string) (*ResolvedPackage, error) {
 }
 
 func (r *resolver) resolveGitHub(target string) (*ResolvedPackage, error) {
-	repo := strings.TrimPrefix(target, "github:")
-	r.logger.Info("cloning GitHub repo", "repo", repo)
+	gt, err := parseGitHubTarget(target)
+	if err != nil {
+		return nil, err
+	}
+
+	r.logger.Info("cloning GitHub repo",
+		"owner", gt.owner,
+		"repo", gt.repo,
+		"subpath", gt.subpath,
+		"ref", gt.ref,
+	)
 
 	tmpDir, err := os.MkdirTemp("", "oxvault-scan-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temp dir: %w", err)
 	}
 
-	url := fmt.Sprintf("https://github.com/%s.git", repo)
-	cmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("git clone %s: %w", repo, err)
+	scanPath, err := r.cloneGitHub(tmpDir, gt)
+	if err != nil {
+		return nil, err
 	}
 
-	lang := detectProjectLanguage(tmpDir)
-	command, args := detectServerCommand(tmpDir, lang)
+	lang := detectProjectLanguage(scanPath)
+	command, args := detectServerCommand(scanPath, lang)
+
+	// Name reflects what is actually scanned: the repo, or the sub-directory
+	// when a subpath was requested.
+	name := gt.repo
+	if gt.subpath != "" {
+		name = filepath.Base(gt.subpath)
+	}
 
 	return &ResolvedPackage{
-		Path:     tmpDir,
+		Path:     scanPath,
 		Command:  command,
 		Args:     args,
 		Language: lang,
-		Name:     filepath.Base(repo),
+		Name:     name,
 	}, nil
+}
+
+// cloneGitHub clones gt into tmpDir and returns the local path that should be
+// scanned. With no subpath it performs a plain shallow clone of the whole repo
+// (unchanged legacy behaviour). With a subpath it attempts a blobless sparse
+// checkout so only that directory is fetched, falling back to a full shallow
+// clone when the installed git lacks sparse-checkout support.
+func (r *resolver) cloneGitHub(tmpDir string, gt githubTarget) (string, error) {
+	url := gitHubRepoURL(gt.owner, gt.repo)
+
+	if gt.subpath == "" {
+		if err := r.gitClone(tmpDir, url, gt.ref); err != nil {
+			return "", fmt.Errorf("git clone %s/%s: %w", gt.owner, gt.repo, err)
+		}
+		return tmpDir, nil
+	}
+
+	if err := r.gitSparseClone(tmpDir, url, gt); err != nil {
+		// Older git (< 2.25) lacks --sparse / sparse-checkout. Fall back to a
+		// full shallow clone and simply point at the subpath afterwards.
+		r.logger.Warn("sparse checkout unavailable; falling back to full clone",
+			"error", err)
+		if rmErr := os.RemoveAll(tmpDir); rmErr != nil {
+			return "", fmt.Errorf("clean failed sparse clone: %w", rmErr)
+		}
+		if mkErr := os.MkdirAll(tmpDir, 0o755); mkErr != nil {
+			return "", fmt.Errorf("recreate temp dir: %w", mkErr)
+		}
+		if cloneErr := r.gitClone(tmpDir, url, gt.ref); cloneErr != nil {
+			return "", fmt.Errorf("git clone %s/%s: %w", gt.owner, gt.repo, cloneErr)
+		}
+	}
+
+	scanPath := filepath.Join(tmpDir, filepath.FromSlash(gt.subpath))
+	if _, err := os.Stat(scanPath); err != nil {
+		return "", fmt.Errorf("subpath %q not found in %s/%s: %w",
+			gt.subpath, gt.owner, gt.repo, err)
+	}
+	return scanPath, nil
+}
+
+// gitClone performs a plain shallow clone of url into tmpDir, optionally
+// checking out a specific branch or tag ref.
+func (r *resolver) gitClone(tmpDir, url, ref string) error {
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, tmpDir)
+
+	cmd := exec.Command("git", args...)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// gitSparseClone performs a blobless sparse checkout that fetches only gt.subpath:
+//
+//	git clone --depth 1 --filter=blob:none --sparse <url> <tmpDir>
+//	git -C <tmpDir> sparse-checkout set <subpath>
+//
+// It returns an error (leaving tmpDir for the caller to clean) when the
+// installed git does not support sparse checkout, so the caller can fall back.
+func (r *resolver) gitSparseClone(tmpDir, url string, gt githubTarget) error {
+	cloneArgs := []string{"clone", "--depth", "1", "--filter=blob:none", "--sparse"}
+	if gt.ref != "" {
+		cloneArgs = append(cloneArgs, "--branch", gt.ref)
+	}
+	cloneArgs = append(cloneArgs, url, tmpDir)
+
+	clone := exec.Command("git", cloneArgs...)
+	clone.Stderr = os.Stderr
+	if err := clone.Run(); err != nil {
+		return fmt.Errorf("sparse clone: %w", err)
+	}
+
+	set := exec.Command("git", "-C", tmpDir, "sparse-checkout", "set", gt.subpath)
+	set.Stderr = os.Stderr
+	if err := set.Run(); err != nil {
+		return fmt.Errorf("sparse-checkout set %q: %w", gt.subpath, err)
+	}
+	return nil
+}
+
+// parseGitHubTarget parses a `github:` target into its owner, repo, optional
+// subpath and optional @ref. Accepted forms:
+//
+//	github:owner/repo
+//	github:owner/repo/sub/dir
+//	github:owner/repo@ref
+//	github:owner/repo/sub/dir@ref
+//
+// The subpath is validated to reject absolute paths and `..` traversal so a
+// target can never escape the cloned repository root.
+func parseGitHubTarget(target string) (githubTarget, error) {
+	raw := strings.TrimPrefix(target, "github:")
+
+	// Optional @ref suffix: everything after the first '@'. owner/repo/subpath
+	// components never legitimately contain '@'.
+	var ref string
+	if at := strings.Index(raw, "@"); at >= 0 {
+		ref = raw[at+1:]
+		raw = raw[:at]
+		if ref == "" {
+			return githubTarget{}, fmt.Errorf("invalid github target %q: empty ref after '@'", target)
+		}
+	}
+
+	raw = strings.Trim(raw, "/")
+	if raw == "" {
+		return githubTarget{}, fmt.Errorf("invalid github target %q: missing owner/repo", target)
+	}
+
+	parts := strings.Split(raw, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return githubTarget{}, fmt.Errorf("invalid github target %q: expected owner/repo", target)
+	}
+
+	gt := githubTarget{owner: parts[0], repo: parts[1], ref: ref}
+
+	if len(parts) > 2 {
+		subpath, err := validateSubpath(strings.Join(parts[2:], "/"))
+		if err != nil {
+			return githubTarget{}, fmt.Errorf("invalid github target %q: %w", target, err)
+		}
+		gt.subpath = subpath
+	}
+
+	return gt, nil
+}
+
+// validateSubpath rejects absolute paths and any `..` segment, then returns a
+// cleaned, forward-slash relative path safe to join against the clone root.
+func validateSubpath(subpath string) (string, error) {
+	if strings.HasPrefix(subpath, "/") || filepath.IsAbs(subpath) {
+		return "", fmt.Errorf("subpath %q must be relative to the repository root", subpath)
+	}
+	for _, seg := range strings.Split(subpath, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("subpath %q must not contain '..' segments", subpath)
+		}
+		// A leading '-' would let git interpret the segment as a flag when it
+		// is passed to `sparse-checkout set`. No shell is involved (argv, not a
+		// shell string), so this is defence-in-depth against argument injection.
+		if strings.HasPrefix(seg, "-") {
+			return "", fmt.Errorf("subpath %q must not contain a segment starting with '-'", subpath)
+		}
+	}
+	cleaned := path.Clean(subpath)
+	if cleaned == "." || cleaned == "" {
+		return "", fmt.Errorf("subpath %q is empty", subpath)
+	}
+	return cleaned, nil
 }
 
 func isLocalPath(target string) bool {

--- a/providers/resolver_test.go
+++ b/providers/resolver_test.go
@@ -3,7 +3,9 @@ package providers
 import (
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -474,6 +476,255 @@ func TestResolve_GitHubPrefix_ReturnsError(t *testing.T) {
 	// We expect an error because git clone will fail
 	if err == nil {
 		t.Error("expected error for invalid GitHub repo (no network or nonexistent)")
+	}
+}
+
+// ── parseGitHubTarget ─────────────────────────────────────────────────────────
+
+func TestParseGitHubTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		wantErr     bool
+		wantOwner   string
+		wantRepo    string
+		wantSubpath string
+		wantRef     string
+	}{
+		{
+			name:      "repo only",
+			target:    "github:oxvault/scanner",
+			wantOwner: "oxvault", wantRepo: "scanner",
+		},
+		{
+			name:      "repo only trailing slash",
+			target:    "github:oxvault/scanner/",
+			wantOwner: "oxvault", wantRepo: "scanner",
+		},
+		{
+			name:        "repo with subpath",
+			target:      "github:oxvault/scanner/examples/vulnerable-servers/tool-poisoning",
+			wantOwner:   "oxvault",
+			wantRepo:    "scanner",
+			wantSubpath: "examples/vulnerable-servers/tool-poisoning",
+		},
+		{
+			name:      "subpath trailing slash normalised",
+			target:    "github:oxvault/scanner/examples/foo/",
+			wantOwner: "oxvault", wantRepo: "scanner",
+			wantSubpath: "examples/foo",
+		},
+		{
+			name:      "repo with ref",
+			target:    "github:oxvault/scanner@v1.2.3",
+			wantOwner: "oxvault", wantRepo: "scanner", wantRef: "v1.2.3",
+		},
+		{
+			name:      "repo with subpath and ref",
+			target:    "github:oxvault/scanner/examples/foo@main",
+			wantOwner: "oxvault", wantRepo: "scanner",
+			wantSubpath: "examples/foo", wantRef: "main",
+		},
+		{
+			name:    "traversal rejected",
+			target:  "github:oxvault/scanner/../secret",
+			wantErr: true,
+		},
+		{
+			name:    "nested traversal rejected",
+			target:  "github:oxvault/scanner/examples/../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "absolute subpath rejected",
+			target:  "github:oxvault/scanner//etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "missing repo",
+			target:  "github:oxvault",
+			wantErr: true,
+		},
+		{
+			name:    "empty target",
+			target:  "github:",
+			wantErr: true,
+		},
+		{
+			name:    "empty ref",
+			target:  "github:oxvault/scanner@",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gt, err := parseGitHubTarget(tt.target)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseGitHubTarget(%q) = %+v, want error", tt.target, gt)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseGitHubTarget(%q) unexpected error: %v", tt.target, err)
+			}
+			if gt.owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", gt.owner, tt.wantOwner)
+			}
+			if gt.repo != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", gt.repo, tt.wantRepo)
+			}
+			if gt.subpath != tt.wantSubpath {
+				t.Errorf("subpath = %q, want %q", gt.subpath, tt.wantSubpath)
+			}
+			if gt.ref != tt.wantRef {
+				t.Errorf("ref = %q, want %q", gt.ref, tt.wantRef)
+			}
+		})
+	}
+}
+
+func TestValidateSubpath_Traversal(t *testing.T) {
+	bad := []string{
+		"..",
+		"../etc",
+		"a/../../b",
+		"/etc/passwd",
+		"", // becomes "." after clean
+		".",
+		"-flag",            // leading dash could be read as a git flag
+		"examples/-inject", // leading-dash segment mid-path
+	}
+	for _, sp := range bad {
+		t.Run(sp, func(t *testing.T) {
+			if _, err := validateSubpath(sp); err == nil {
+				t.Errorf("validateSubpath(%q) = nil error, want rejection", sp)
+			}
+		})
+	}
+}
+
+func TestResolve_GitHubSubpathTraversal_NoClone(t *testing.T) {
+	// A traversal target must be rejected during parsing, before any git clone
+	// is attempted. This is fully hermetic (no git / network required).
+	r := newResolver(t)
+	_, err := r.Resolve("github:oxvault/scanner/../secret")
+	if err == nil {
+		t.Fatal("expected error for traversal subpath")
+	}
+	if !strings.Contains(err.Error(), "..") {
+		t.Errorf("expected error to mention '..', got %v", err)
+	}
+}
+
+// ── Resolve — github sparse checkout (hermetic, local git repo) ───────────────
+
+// makeLocalGitRepo builds a real git repository on disk with the given files
+// (map of forward-slash relative path → contents) and returns its path. Tests
+// point gitHubRepoURL at this via a file:// URL so no network is used.
+func makeLocalGitRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; skipping sparse-checkout integration test")
+	}
+
+	dir := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	git("init", "-b", "main")
+	for rel, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("add", "-A")
+	git("commit", "-m", "initial")
+	return dir
+}
+
+func TestResolve_GitHubSubpath_SparseCheckout(t *testing.T) {
+	src := makeLocalGitRepo(t, map[string]string{
+		"README.md":                         "# root",
+		"examples/foo/requirements.txt":     "fastmcp",
+		"examples/foo/server.py":            "# target server",
+		"examples/bar/other.txt":            "sibling that must NOT be fetched",
+		"examples/bar/should_not_exist.txt": "x",
+	})
+
+	orig := gitHubRepoURL
+	t.Cleanup(func() { gitHubRepoURL = orig })
+	gitHubRepoURL = func(owner, repo string) string { return "file://" + src }
+
+	r := newResolver(t)
+	pkg, err := r.Resolve("github:oxvault/scanner/examples/foo")
+	if err != nil {
+		t.Fatalf("Resolve subpath error: %v", err)
+	}
+
+	// Path must point into the requested subpath.
+	if base := filepath.Base(pkg.Path); base != "foo" {
+		t.Errorf("expected Path to end in /foo, got %q", pkg.Path)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(pkg.Path), "examples/foo") {
+		t.Errorf("expected Path to end in examples/foo, got %q", pkg.Path)
+	}
+
+	// The subpath's contents must be present...
+	if _, err := os.Stat(filepath.Join(pkg.Path, "server.py")); err != nil {
+		t.Errorf("expected server.py checked out in subpath: %v", err)
+	}
+	// ...and language detection must have run against the subpath.
+	if pkg.Language != LangPython {
+		t.Errorf("expected LangPython (from subpath requirements.txt), got %v", pkg.Language)
+	}
+	if pkg.Command != "python3" {
+		t.Errorf("expected Command=python3, got %q", pkg.Command)
+	}
+	if pkg.Name != "foo" {
+		t.Errorf("expected Name=foo, got %q", pkg.Name)
+	}
+
+	// Sparse checkout must NOT have materialised the sibling directory — this
+	// is what proves only the subpath was fetched rather than the whole tree.
+	cloneRoot := filepath.Dir(filepath.Dir(pkg.Path)) // <tmp> (parent of examples/)
+	if _, err := os.Stat(filepath.Join(cloneRoot, "examples", "bar", "other.txt")); !os.IsNotExist(err) {
+		t.Errorf("sibling examples/bar/other.txt should not be checked out (sparse), stat err = %v", err)
+	}
+}
+
+func TestResolve_GitHubSubpath_Missing(t *testing.T) {
+	src := makeLocalGitRepo(t, map[string]string{
+		"README.md":              "# root",
+		"examples/foo/server.py": "# server",
+	})
+
+	orig := gitHubRepoURL
+	t.Cleanup(func() { gitHubRepoURL = orig })
+	gitHubRepoURL = func(owner, repo string) string { return "file://" + src }
+
+	r := newResolver(t)
+	_, err := r.Resolve("github:oxvault/scanner/examples/does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent subpath")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Enhances the `github:` scan target to accept an optional **subpath** and fetch only that directory via a **blobless sparse checkout**, instead of always full-cloning the whole repo and scanning its root.

### New target syntax
| Target | Behaviour |
|---|---|
| `github:owner/repo` | Full shallow clone of the root — **unchanged legacy behaviour** |
| `github:owner/repo/sub/dir` | Sparse-fetch only `sub/dir`; scan points at it |
| `github:owner/repo@ref` | Full clone at tag/branch `ref` |
| `github:owner/repo/sub@ref` | Sparse-fetch `sub` at tag/branch `ref` |

### How the sparse fetch works
```
git clone --depth 1 --filter=blob:none --sparse <url> <tmp>
git -C <tmp> sparse-checkout set <subpath>
```
Resolved `Path` becomes `<tmp>/<subpath>`, so language/command detection (`detectProjectLanguage`, `detectServerCommand`) runs against just that directory.

### Safety & robustness
- **Path traversal rejected** — absolute paths and any `..` segment are refused during parse, before any clone runs.
- **Missing subpath** after checkout returns a clear `subpath %q not found` error.
- **Graceful fallback** — if the installed git lacks sparse-checkout (< 2.25), falls back to a full shallow clone then points at the subpath.
- `@ref` honoured via `--branch` (tags/branches; commit SHAs not supported with `--depth 1`).

## Tests (hermetic — no network / github)
- Table-driven `parseGitHubTarget` cases: repo-only, subpath, `@ref`, subpath+ref, traversal rejected, absolute rejected, missing repo, empty ref.
- `validateSubpath` traversal table.
- Integration tests build a **real local git repo**, point the clone URL at it via a `file://` URL, and assert the requested subpath is checked out while sibling directories are **not** present on disk — proving the sparse fetch (not a full clone). A missing-subpath case asserts the clear error. Skips cleanly if `git` is absent.

## Compatibility
`Resolve`'s switch is untouched; `hf:`, npm, and local-path resolution are unaffected. Existing `github:owner/repo` resolves exactly as before.

Unblocks the console onboarding one-liner:
```
oxvault scan github:oxvault/scanner/examples/vulnerable-servers/tool-poisoning --skip-manifest
```

Quality gates: `make check` (build + test + lint, 0 issues) and `make build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)