### PR TITLE
fix(resolver): reject github @ref starting with '-' (arg-injection parity)

### DIFF
--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -295,6 +295,13 @@ func parseGitHubTarget(target string) (githubTarget, error) {
 		if ref == "" {
 			return githubTarget{}, fmt.Errorf("invalid github target %q: empty ref after '@'", target)
 		}
+		// A leading '-' would let git interpret the ref as a flag if the
+		// `--branch <ref>` argv ordering ever changed (e.g. --upload-pack).
+		// ref is always passed as --branch's value today, but reject it for
+		// parity with validateSubpath — defence-in-depth against arg injection.
+		if strings.HasPrefix(ref, "-") {
+			return githubTarget{}, fmt.Errorf("invalid github target %q: ref must not start with '-'", target)
+		}
 	}
 
 	raw = strings.Trim(raw, "/")


### PR DESCRIPTION
Follow-up to #46 — the ref leading-dash guard raced the merge and didn't land. `validateSubpath` rejects leading-`-` segments; apply the same to the `@ref` so `github:o/r@--upload-pack=x` can't smuggle a git flag. ref is always `--branch`'s value today (not currently exploitable), so this is defence-in-depth parity. From the inline security review of #46. build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)