### PR TITLE
fix(cli): broaden tagline beyond MCP to AI supply chain

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ var version = iversion.Version
 func main() {
 	root := &cobra.Command{
 		Use:     "oxvault",
-		Short:   "MCP security scanner — detect vulnerabilities in AI tool integrations",
+		Short:   "Security scanner for the AI supply chain — MCP servers, ML models & more",
 		Version: version,
 		Run: func(cmd *cobra.Command, args []string) {
 			printLogo()
@@ -108,7 +108,7 @@ func printLogo() {
 		bold.Sprint("Oxvault Scanner"),
 		dim.Sprint(version))
 	fmt.Fprintf(os.Stderr, "  %s\n\n",
-		dim.Sprint("MCP security scanner — detect vulnerabilities in AI tool integrations"))
+		dim.Sprint("Security scanner for the AI supply chain — MCP servers, ML models & more"))
 }
 
 // printProgress writes a styled progress line to stderr.


### PR DESCRIPTION
The root command `Short` + the `printLogo` banner still read "MCP security scanner — detect vulnerabilities in AI tool integrations", but the scanner now covers MCP servers **and** ML model artifacts (AIBOM), RAG planned. Both lines → "Security scanner for the AI supply chain — MCP servers, ML models & more" (matches the README headline; avoids overclaiming RAG as shipped). build green.

Ships to users on the next scanner release.