### PR TITLE
fix(cli): keep github: scheme in artifact name so agent rescans resolve

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,11 +56,7 @@ func artifactTypeFor(pkg *providers.ResolvedPackage) string {
 func deriveArtifactName(target string) string {
 	t := strings.TrimSpace(target)
 	switch {
-	// Remote-scheme targets keep their scheme: the name is both the
-	// (workspace_id, name) upsert key AND the target the agent re-resolves on
-	// rescan. Stripping "github:" made the agent see a bare "owner/repo/subpath"
-	// and treat it as a local path (isRemoteSchemeTarget only matches the
-	// github: prefix or a single-slash bare pkg) — so remote rescans failed.
+	// Keep the scheme — the name is the agent's rescan target; stripping "github:" made it look local and broke remote rescans.
 	case strings.HasPrefix(t, "github:") || strings.HasPrefix(t, "hf:") || strings.HasPrefix(t, "@"):
 		return t
 	default:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,9 +56,12 @@ func artifactTypeFor(pkg *providers.ResolvedPackage) string {
 func deriveArtifactName(target string) string {
 	t := strings.TrimSpace(target)
 	switch {
-	case strings.HasPrefix(t, "github:"):
-		return strings.TrimPrefix(t, "github:")
-	case strings.HasPrefix(t, "@") || strings.HasPrefix(t, "hf:"):
+	// Remote-scheme targets keep their scheme: the name is both the
+	// (workspace_id, name) upsert key AND the target the agent re-resolves on
+	// rescan. Stripping "github:" made the agent see a bare "owner/repo/subpath"
+	// and treat it as a local path (isRemoteSchemeTarget only matches the
+	// github: prefix or a single-slash bare pkg) — so remote rescans failed.
+	case strings.HasPrefix(t, "github:") || strings.HasPrefix(t, "hf:") || strings.HasPrefix(t, "@"):
 		return t
 	default:
 		return filepath.Base(filepath.Clean(t))

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -60,3 +60,24 @@ func TestSplitAndTrimCSV(t *testing.T) {
 		})
 	}
 }
+
+// TestDeriveArtifactName pins the scan-target → artifact-name mapping. The
+// name is the (workspace_id, name) upsert key AND the target the agent
+// re-resolves on rescan, so remote-scheme targets MUST keep their scheme —
+// stripping "github:" made owner/repo/subpath look local and broke rescans.
+func TestDeriveArtifactName(t *testing.T) {
+	tests := map[string]string{
+		"github:oxvault/scanner": "github:oxvault/scanner",
+		"github:oxvault/scanner/examples/vulnerable-servers/tool-poisoning": "github:oxvault/scanner/examples/vulnerable-servers/tool-poisoning",
+		"github:owner/repo@v1.2.3": "github:owner/repo@v1.2.3",
+		"hf:org/model":             "hf:org/model",
+		"@company/mcp-server":      "@company/mcp-server",
+		"./node_modules/asana-mcp": "asana-mcp",
+		"/tmp/models/model.pkl":    "model.pkl",
+	}
+	for target, want := range tests {
+		if got := deriveArtifactName(target); got != want {
+			t.Errorf("deriveArtifactName(%q) = %q; want %q", target, got, want)
+		}
+	}
+}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -61,10 +61,7 @@ func TestSplitAndTrimCSV(t *testing.T) {
 	}
 }
 
-// TestDeriveArtifactName pins the scan-target → artifact-name mapping. The
-// name is the (workspace_id, name) upsert key AND the target the agent
-// re-resolves on rescan, so remote-scheme targets MUST keep their scheme —
-// stripping "github:" made owner/repo/subpath look local and broke rescans.
+// TestDeriveArtifactName: remote-scheme targets keep their scheme (it's the agent's rescan key); local paths reduce to basename.
 func TestDeriveArtifactName(t *testing.T) {
 	tests := map[string]string{
 		"github:oxvault/scanner": "github:oxvault/scanner",


### PR DESCRIPTION
**Bug:** `oxvault agent` rescan of a github target failed — `could not locate artifact "oxvault/scanner/examples/vulnerable-servers/tool-poisoning" (tried 4 paths)`.

**Cause:** `deriveArtifactName` stripped the `github:` scheme, so the artifact persisted as a bare multi-slash `owner/repo/subpath`. On rescan the agent's `isRemoteSchemeTarget` (matches `github:` prefix or a *single-slash* bare pkg) didn't classify it as remote → local-FS probe → fail. `hf:`/`@` already kept their scheme; github was the odd one out.

**Fix:** keep the scheme for `github:`/`hf:`/`@` — the name is both the upsert key and the agent's rescan target, so it must stay a resolvable remote target. + `TestDeriveArtifactName` round-trip. build + tests green.

Note: existing artifacts already stored with the stripped name won't retro-fix — re-scan them fresh (or use `--target-map`) after this ships. Ships in the next scanner release.