### PR TITLE
fix(scan): remove remote-scan temp dirs after scanning

### DIFF
--- a/engines/scanner.go
+++ b/engines/scanner.go
@@ -3,6 +3,7 @@ package engines
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/oxvault/scanner/providers"
@@ -127,6 +128,16 @@ func (s *scanner) Scan(target string, opts ScanOptions) (*ScanReport, error) {
 		return nil, fmt.Errorf("resolve: %w", err)
 	}
 	report.Package = pkg
+
+	// Remote resolvers stage the artifact in a temp dir — remove it on return
+	// so untrusted code isn't left on disk. Local paths / HF cache: no TempDir.
+	if pkg.TempDir != "" {
+		defer func() {
+			if rmErr := os.RemoveAll(pkg.TempDir); rmErr != nil {
+				s.logger.Warn("failed to remove scan temp dir", "dir", pkg.TempDir, "error", rmErr)
+			}
+		}()
+	}
 
 	// AIBOM dispatch — model artifacts and model directories run through
 	// the AIBOMComposer instead of the MCP-server pipeline. MCP-server

--- a/engines/scanner_test.go
+++ b/engines/scanner_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1317,5 +1319,40 @@ func TestScanner_ProbeNetwork_SkippedWhenNoCommand(t *testing.T) {
 	if probe.CallCount.Load() != 0 {
 		t.Errorf("probe should not be called when pkg.Command is empty, got %d calls",
 			probe.CallCount.Load())
+	}
+}
+
+// Remote scan's TempDir is removed after the scan.
+func TestScanner_Scan_RemovesTempDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "clone")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resolver := &testutil.MockResolver{ResolveResult: &providers.ResolvedPackage{
+		Path: dir, TempDir: dir, Kind: providers.KindMCPServer,
+	}}
+	eng := newTestScanner(resolver, &testutil.MockMCPClient{}, &testutil.MockRuleMatcher{},
+		&testutil.MockSASTAnalyzer{}, &testutil.MockReporter{})
+
+	_, _ = eng.Scan("github:o/r", ScanOptions{SkipSAST: true, SkipDepAudit: true, SkipManifest: true, SkipEgress: true})
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("temp dir %q not removed after scan (stat err: %v)", dir, err)
+	}
+}
+
+// Local target (no TempDir) is never deleted.
+func TestScanner_Scan_KeepsLocalPath(t *testing.T) {
+	dir := t.TempDir()
+	resolver := &testutil.MockResolver{ResolveResult: &providers.ResolvedPackage{
+		Path: dir, TempDir: "", Kind: providers.KindMCPServer,
+	}}
+	eng := newTestScanner(resolver, &testutil.MockMCPClient{}, &testutil.MockRuleMatcher{},
+		&testutil.MockSASTAnalyzer{}, &testutil.MockReporter{})
+
+	_, _ = eng.Scan("./local", ScanOptions{SkipSAST: true, SkipDepAudit: true, SkipManifest: true, SkipEgress: true})
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("local path %q was removed (must not be): %v", dir, err)
 	}
 }

--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -147,6 +147,7 @@ func (r *resolver) resolveNPM(packageName string) (*ResolvedPackage, error) {
 		Args:     []string{"-y", packageName},
 		Language: LangJavaScript,
 		Name:     packageName,
+		TempDir:  tmpDir,
 	}, nil
 }
 
@@ -189,6 +190,7 @@ func (r *resolver) resolveGitHub(target string) (*ResolvedPackage, error) {
 		Args:     args,
 		Language: lang,
 		Name:     name,
+		TempDir:  tmpDir,
 	}, nil
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -147,6 +147,9 @@ type ResolvedPackage struct {
 	Language Language // Detected primary language
 	Name     string   // Package name
 	Version  string   // Package version
+	// TempDir: resolver-created temp dir the caller removes after scanning
+	// (github/npm). Empty for local paths + HF cache — never removed.
+	TempDir string
 	// Kind classifies the package. The zero value is treated as KindMCPServer
 	// for backwards-compatibility with pre-AIBOM call sites.
 	Kind PackageKind


### PR DESCRIPTION
Remote resolvers (github/npm) staged the artifact in `os.MkdirTemp("oxvault-scan-*")` and **nothing removed it** — untrusted cloned code / node_modules leaked to /tmp on every remote scan (disk + a security-hygiene issue for a tool that scans malicious artifacts).

**Fix:** `ResolvedPackage.TempDir` (set only by the temp-creating resolvers) + a `defer os.RemoveAll` in the scan engine, firing on any return path. Local paths + the persistent HF cache (`~/.cache/oxvault/hf`) set no TempDir → never touched. Tests: remote temp dir removed after scan, local path kept intact. build + tests green.

Ships next release (fix → patch bump).