### PR TITLE
chore(version): fallback to "dev" instead of a stale release number

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,9 @@
 // Package version holds the single source of truth for the scanner version.
 package version
 
-// Version is the canonical version string. Override at build time with:
+// Version is the scanner version. Releases inject the git tag at build time
+// (Makefile / GoReleaser ldflags); this "dev" default is what un-ldflagged
+// builds (go run, go install) report — never a stale release number.
 //
 //	go build -ldflags "-X github.com/oxvault/scanner/internal/version.Version=x.y.z"
-var Version = "0.4.0"
+var Version = "dev"


### PR DESCRIPTION
`internal/version.Version` was hardcoded `0.4.0` while releases are v0.7.x — misleading for un-ldflagged builds (`go run`, `go install …/cmd@latest`). Releases inject the git tag via ldflags (Makefile + GoReleaser) regardless, so the default → `"dev"`: non-release builds report "dev" instead of a stale number, and this const never needs bumping again. build + tests green.