### PR TITLE
feat(scan): bare `scan` = auto, fix installed-server discovery

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -203,22 +203,28 @@ func newScanCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "scan [target]",
-		Short: "Scan an MCP server for security vulnerabilities",
-		Long: `Scan an MCP server project, npm package, or GitHub repo for security vulnerabilities.
+		Short: "Scan MCP servers and AI model artifacts for security vulnerabilities",
+		Long: `Scan MCP servers, npm packages, GitHub repos, or ML model artifacts for
+security vulnerabilities.
+
+Run with no target to scan every MCP server already installed on this machine
+(Claude Code, Claude Desktop, Cursor, VS Code, Windsurf) — same as --config auto.
 
 Targets:
+  (none)                         Auto-detect and scan all installed MCP servers
   ./my-server                    Local project directory or file
   @company/mcp-server            npm package (downloaded to temp dir)
   github:user/repo               GitHub repository (cloned)
   github:user/repo/sub/dir       GitHub sub-directory (sparse-fetched)
 
 Config-based scanning:
-  --config ~/.claude/claude_desktop_config.json   Scan all servers in a config file
-  --config auto                                   Auto-detect all known MCP config files`,
+  --config <path>                Scan all servers in a specific config file
+  --config auto                  Auto-detect all known MCP config files`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// No target and no --config: scan everything already installed.
 			if configPath == "" && len(args) == 0 {
-				return fmt.Errorf("provide a scan target or --config flag\n\nRun 'oxvault scan --help' for usage")
+				configPath = "auto"
 			}
 
 			cfg := config.DefaultConfig()
@@ -327,7 +333,7 @@ Config-based scanning:
 	cmd.Flags().BoolVar(&skipEgress, "skip-egress", false, "Skip network egress detection")
 	cmd.Flags().BoolVar(&probeNetwork, "probe-network", false, "Spawn server and monitor outbound connections (requires strace on Linux)")
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output (for CI or piping)")
-	cmd.Flags().StringVar(&configPath, "config", "", "MCP client config file to scan (path or \"auto\")")
+	cmd.Flags().StringVar(&configPath, "config", "", "MCP client config file to scan (path or \"auto\"; auto is the default when no target is given)")
 	cmd.Flags().BoolVar(&showSuppressed, "show-suppressed", false, "Print suppressed findings in a separate section")
 
 	// HF resolver flags (v0.4 AIBOM)
@@ -548,7 +554,13 @@ func runConfigScan(application *app.App, cfg *config.Config, opts engines.ScanOp
 	}
 
 	if len(result.Servers) == 0 {
-		fmt.Fprintf(os.Stderr, "  No MCP servers found in config.\n")
+		if configPath == "auto" {
+			fmt.Fprintf(os.Stderr, "  No installed MCP servers found.\n\n"+
+				"  Point at a target directly:  oxvault scan github:user/repo\n"+
+				"  Or a specific config file:   oxvault scan --config <path>\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "  No MCP servers found in config.\n")
+		}
 		return nil
 	}
 
@@ -574,6 +586,21 @@ func runConfigScan(application *app.App, cfg *config.Config, opts engines.ScanOp
 	anyFailed := false
 
 	for _, srv := range result.Servers {
+		// Remote (http/sse) servers expose only a URL — nothing local to scan.
+		if srv.Command == "" {
+			if cfg.OutputFormat == providers.FormatTerminal {
+				transport := srv.Transport
+				if transport == "" {
+					transport = "remote"
+				}
+				fmt.Fprintf(os.Stderr, "  %s %s %s\n\n",
+					color.New(color.FgYellow).Sprint("──"),
+					color.New(color.Bold).Sprint(srv.Name),
+					color.New(color.Faint).Sprintf("(%s transport — static scan not applicable)", transport))
+			}
+			continue
+		}
+
 		startedAt := time.Now().UTC()
 		// Build the target string that the resolver understands.
 		// For config-defined servers the command IS the target — we pass it

--- a/config/discover.go
+++ b/config/discover.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // MCPServerConfig holds the configuration for a single MCP server entry
@@ -22,6 +24,12 @@ type MCPServerConfig struct {
 	// Env is the environment variables to set for the process
 	Env map[string]string `json:"env"`
 
+	// Transport is "" / "stdio" for command servers, "http" / "sse" for remote.
+	Transport string
+
+	// URL is the endpoint for http/sse transports (empty for stdio servers).
+	URL string
+
 	// Source is the config file this server was loaded from
 	Source string
 }
@@ -30,12 +38,18 @@ type MCPServerConfig struct {
 // The outer object may contain extra fields (e.g. globalShortcut) which we ignore.
 type mcpClientConfig struct {
 	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+	// Projects holds Claude Code's per-project sections (~/.claude.json).
+	Projects map[string]struct {
+		MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+	} `json:"projects"`
 }
 
 type mcpServerEntry struct {
 	Command string            `json:"command"`
 	Args    []string          `json:"args"`
 	Env     map[string]string `json:"env"`
+	Type    string            `json:"type"`
+	URL     string            `json:"url"`
 }
 
 // knownConfigPaths returns the canonical list of MCP client config file paths
@@ -49,18 +63,35 @@ func knownConfigPaths() []string {
 	}
 
 	return []string{
-		// Claude Desktop
-		filepath.Join(home, ".claude", "claude_desktop_config.json"),
-		// Claude Code
-		filepath.Join(home, ".claude", "claude_code_config.json"),
-		// Cursor
+		// Claude Code — global + project-scoped servers (nested structure).
+		filepath.Join(home, ".claude.json"),
+		// Claude Code — project-shared config (cwd-relative).
+		".mcp.json",
+		// Claude Desktop — OS-specific application-support location.
+		claudeDesktopConfigPath(home),
+		// Cursor — global + project (cwd-relative).
 		filepath.Join(home, ".cursor", "mcp.json"),
-		// VS Code (user-level)
+		filepath.Join(".cursor", "mcp.json"),
+		// VS Code — user-level + workspace (cwd-relative).
 		filepath.Join(home, ".vscode", "mcp.json"),
-		// VS Code (workspace-level — resolved relative to cwd)
 		filepath.Join(".vscode", "mcp.json"),
-		// Windsurf / Codeium
+		// Windsurf / Codeium.
 		filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"),
+	}
+}
+
+// claudeDesktopConfigPath returns the OS-specific Claude Desktop config location.
+func claudeDesktopConfigPath(home string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
+	case "windows":
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "Claude", "claude_desktop_config.json")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "Claude", "claude_desktop_config.json")
+	default: // linux + other unix
+		return filepath.Join(home, ".config", "Claude", "claude_desktop_config.json")
 	}
 }
 
@@ -83,14 +114,22 @@ func ParseConfigFile(path string) ([]MCPServerConfig, error) {
 	}
 
 	servers := make([]MCPServerConfig, 0, len(raw.MCPServers))
-	for name, entry := range raw.MCPServers {
-		servers = append(servers, MCPServerConfig{
-			Name:    name,
-			Command: entry.Command,
-			Args:    entry.Args,
-			Env:     entry.Env,
-			Source:  path,
-		})
+	collect := func(m map[string]mcpServerEntry) {
+		for name, entry := range m {
+			servers = append(servers, MCPServerConfig{
+				Name:      name,
+				Command:   entry.Command,
+				Args:      entry.Args,
+				Env:       entry.Env,
+				Transport: entry.Type,
+				URL:       entry.URL,
+				Source:    path,
+			})
+		}
+	}
+	collect(raw.MCPServers)
+	for _, proj := range raw.Projects {
+		collect(proj.MCPServers)
 	}
 
 	return servers, nil
@@ -133,6 +172,7 @@ func discoverOne(path string) (*DiscoverResult, error) {
 
 func discoverAll() (*DiscoverResult, error) {
 	result := &DiscoverResult{}
+	seen := make(map[string]bool) // dedup a server that appears in several files
 
 	for _, candidate := range knownConfigPaths() {
 		servers, err := ParseConfigFile(candidate)
@@ -140,13 +180,26 @@ func discoverAll() (*DiscoverResult, error) {
 			// Malformed JSON is a real error — surface it.
 			return nil, err
 		}
-		if len(servers) == 0 {
-			continue
-		}
 
-		result.SourceFiles = append(result.SourceFiles, candidate)
-		result.Servers = append(result.Servers, servers...)
+		added := 0
+		for _, srv := range servers {
+			key := serverIdentity(srv)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			result.Servers = append(result.Servers, srv)
+			added++
+		}
+		if added > 0 {
+			result.SourceFiles = append(result.SourceFiles, candidate)
+		}
 	}
 
 	return result, nil
+}
+
+// serverIdentity keys a server by command + args + url for dedup.
+func serverIdentity(s MCPServerConfig) string {
+	return s.Command + "\x00" + strings.Join(s.Args, "\x00") + "\x00" + s.URL
 }

--- a/config/discover_test.go
+++ b/config/discover_test.go
@@ -79,6 +79,38 @@ func TestParseConfigFile_HappyPath(t *testing.T) {
 	}
 }
 
+func TestParseConfigFile_NestedProjectServers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+	// Claude Code layout: global servers in mcpServers, project-scoped under projects[path].
+	raw := `{
+		"mcpServers": {"context7": {"command": "npx", "args": ["-y", "context7"]}},
+		"projects": {
+			"/home/me/proj": {"mcpServers": {"proj-db": {"command": "python3", "args": ["db.py"]}}}
+		}
+	}`
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	servers, err := ParseConfigFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers (global + project), got %d", len(servers))
+	}
+	names := map[string]bool{}
+	for _, s := range servers {
+		names[s.Name] = true
+	}
+	for _, want := range []string{"context7", "proj-db"} {
+		if !names[want] {
+			t.Errorf("expected server %q, got %v", want, names)
+		}
+	}
+}
+
 func TestParseConfigFile_MissingFile_ReturnsNilNoError(t *testing.T) {
 	servers, err := ParseConfigFile("/nonexistent/path/config.json")
 	if err != nil {
@@ -225,12 +257,8 @@ func TestDiscover_Auto_FindsFilesInKnownLocations(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	// Create .claude dir and a desktop config
-	claudeDir := filepath.Join(dir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	writeConfigFile(t, claudeDir, "claude_desktop_config.json", map[string]mcpServerEntry{
+	// Claude Code global config (~/.claude.json).
+	writeConfigFile(t, dir, ".claude.json", map[string]mcpServerEntry{
 		"fs":     {Command: "npx", Args: []string{"-y", "mcp-fs"}},
 		"github": {Command: "npx", Args: []string{"-y", "mcp-github"}},
 	})
@@ -269,6 +297,31 @@ func TestDiscover_Auto_FindsFilesInKnownLocations(t *testing.T) {
 	}
 }
 
+func TestDiscover_Auto_DedupsIdenticalServers(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Same server (identical command+args) in Claude Code global + Cursor global.
+	writeConfigFile(t, dir, ".claude.json", map[string]mcpServerEntry{
+		"context7": {Command: "npx", Args: []string{"-y", "context7"}},
+	})
+	cursorDir := filepath.Join(dir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfigFile(t, cursorDir, "mcp.json", map[string]mcpServerEntry{
+		"context7-dup": {Command: "npx", Args: []string{"-y", "context7"}},
+	})
+
+	result, err := Discover("auto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Servers) != 1 {
+		t.Errorf("expected 1 server after dedup, got %d: %v", len(result.Servers), result.Servers)
+	}
+}
+
 func TestDiscover_Auto_NoConfigsPresent_ReturnsEmpty(t *testing.T) {
 	// Point HOME at an empty temp directory — no known config files exist.
 	dir := t.TempDir()
@@ -290,13 +343,9 @@ func TestDiscover_Auto_MalformedFile_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	claudeDir := filepath.Join(dir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// Write malformed JSON to a known config path
+	// Write malformed JSON to a known config path (Claude Code global).
 	if err := os.WriteFile(
-		filepath.Join(claudeDir, "claude_desktop_config.json"),
+		filepath.Join(dir, ".claude.json"),
 		[]byte(`{broken`),
 		0o600,
 	); err != nil {
@@ -313,12 +362,8 @@ func TestDiscover_Auto_SkipsEmptyConfigFiles(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	// Create a config with no servers
-	claudeDir := filepath.Join(dir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	writeConfigFile(t, claudeDir, "claude_desktop_config.json", map[string]mcpServerEntry{})
+	// Create a config with no servers (Claude Code global).
+	writeConfigFile(t, dir, ".claude.json", map[string]mcpServerEntry{})
 
 	// Create a config with servers
 	cursorDir := filepath.Join(dir, ".cursor")
@@ -366,10 +411,24 @@ func TestKnownConfigPaths_ContainsClaudeDesktop(t *testing.T) {
 	}
 
 	paths := knownConfigPaths()
-	want := filepath.Join(home, ".claude", "claude_desktop_config.json")
+	want := claudeDesktopConfigPath(home)
 
 	if !slices.Contains(paths, want) {
 		t.Errorf("expected Claude Desktop config path %q in known paths, got %v", want, paths)
+	}
+}
+
+func TestKnownConfigPaths_ContainsClaudeCode(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	paths := knownConfigPaths()
+	want := filepath.Join(home, ".claude.json")
+
+	if !slices.Contains(paths, want) {
+		t.Errorf("expected Claude Code config path %q in known paths, got %v", want, paths)
 	}
 }
 


### PR DESCRIPTION
## What

`oxvault scan` with **no target** now scans every MCP server already installed on the machine (same as `--config auto`) instead of erroring.

## Why

`--config auto` is the frictionless "you already run this" hook — but it was half-broken. On a real macOS machine it found only Cursor and missed Claude Code / Claude Desktop entirely, because the hardcoded paths didn't exist.

## Changes

- **Real client config paths**: `~/.claude.json` (Claude Code, incl. nested `projects[].mcpServers`), OS-specific Claude Desktop location (macOS/Linux/Windows), project-relative `.cursor/mcp.json` and `.mcp.json`. Dropped dead `~/.claude/claude_desktop_config.json` / `claude_code_config.json` entries.
- **http/sse servers**: parse `type` + `url`; dedup a server that appears in several config files.
- **Graceful remote skip**: `runConfigScan` notes and skips url-only (remote) servers instead of scanning an empty target (was printing a bogus `()` + "Pushed 0 findings").
- **Bare `scan` → auto** default.

## Tests

Added: nested `projects[]` parsing, dedup, Claude Code path presence. Updated auto-discovery tests to the new paths. `go build`, `go test ./...` green.

Verified live: `oxvault scan` now finds context7 + linear (both http) and skips them cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)